### PR TITLE
GGA: Correct empty fields count. The four last are normally empty

### DIFF
--- a/hooks/GGA.js
+++ b/hooks/GGA.js
@@ -73,7 +73,7 @@ module.exports = function (input) {
     return e
   }, 0)
 
-  if (empty > 3) {
+  if (empty > 4) {
     return null
   }
 


### PR DESCRIPTION
It's rather normal the GGA message has four empty last fields so the "if (empty > 3) {
    return null" will normally "kick" out GGA.