### PR TITLE
Add Parser ts types

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -52,7 +52,7 @@ export interface IParserOptions {
   onPropertyValues?: (
     propertyName: string,
     onPropertyValuesCallback: IParserOptionsOnPropertyValuesCallback,
-  ) => any;
+  ) => void;
   validateChecksum?: boolean;
 }
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,64 @@
+export interface IParserDelta {
+  updates: {
+    source: string;
+    timestamp: string;
+    values: {
+      path: string;
+      value: any;
+    }[];
+  }[];
+}
+
+export interface IParserDeltaWithSource {
+  updates: {
+    source: {
+      sentence: string;
+      talker: string;
+      type: string;
+    };
+    timestamp: string;
+    values: {
+      path: string;
+      value: any;
+    }[];
+  }[];
+}
+
+export interface IParserArgs {
+  id: string;
+  sentence: string;
+  parts: string[];
+  tags: {
+    source: string;
+    timestamp: string;
+  };
+}
+export interface IParserSession {
+  [key: string]: any;
+}
+
+export interface IPropertyValue {
+  value: {
+    sentence: string;
+    parser: (args: IParserArgs, session: IParserSession) => null | IParserDelta;
+  };
+}
+
+export type IParserOptionsOnPropertyValuesCallback = (
+  val: undefined | IPropertyValue[],
+) => void;
+
+export interface IParserOptions {
+  onPropertyValues?: (
+    propertyName: string,
+    onPropertyValuesCallback: IParserOptionsOnPropertyValuesCallback,
+  ) => any;
+  validateChecksum?: boolean;
+}
+
+declare class Parser {
+  constructor(opts?: IParserOptions);
+  parse<T = (IParserDeltaWithSource | null)>(sentence: string): T;
+}
+
+export default Parser;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.10.0",
   "description": "A node.js/javascript parser for NMEA0183 sentences. Sentences are parsed to Signal K format.",
   "main": "index.js",
+  "types": "./lib/index.d.ts",
   "scripts": {
     "test": "mocha",
     "deploy": "npm test && npm run release && npm publish --access public --scope @signalk .",


### PR DESCRIPTION
I've added some types for the `Parser` class. I noticed you're using typescript in some other SignalK projects so didn't think it'd be too controversial to add these types directly in this repo. I'm happy to add them to DefinitelyTyped if you prefer.

One thing to note, I couldn't quite figure out what was goin on with `emitPropertyValue` so I didn't include that in the constructor interface.

Also, note
```ts
export interface IParserDelta {
  updates: {
    source: string;
    timestamp: string;
    values: {
      path: string;
      value: any;
    }[];
  }[];
}
```
Includes `source` and `timestamp`. These are not included in what is returned from `custom-sentence-plugin`. Not sure if this should be optional or whether `custom-sentence-plugin` should be changed.