### PR TITLE
Fix sign of cross track error obtained from RMB sentence

### DIFF
--- a/hooks/RMB.js
+++ b/hooks/RMB.js
@@ -68,7 +68,7 @@ module.exports = function (input) {
   crossTrackError = utils.float(parts[1])
   crossTrackError = (!isNaN(crossTrackError)) ? crossTrackError : 0.0
 
-  crossTrackError = parts[2] == 'R' ? crossTrackError : -crossTrackError;
+  crossTrackError = parts[2] == 'L' ? crossTrackError : -crossTrackError;
 
   const delta = {
     updates: [

--- a/test/RMB.js
+++ b/test/RMB.js
@@ -38,14 +38,14 @@ describe('RMB', () => {
     delta.updates[0].values[4].value.should.equal(0)
   })
 
-  it('crossTrackError should be positive to steer Right', () => {
+  it('crossTrackError should be negative to steer right', () => {
     const delta = new Parser().parse('$ECRMB,A,0.432,R,001,002,4653.550,N,07115.984,W,2.505,334.205,0.000,V*1F')
-    delta.updates[0].values[4].value.should.be.closeTo(800.064, 0.005)
+    delta.updates[0].values[4].value.should.be.closeTo(-800.064, 0.005)
   })
 
-  it('crossTrackError should be negative to steer left', () => {
+  it('crossTrackError should be positive to steer left', () => {
     const delta = new Parser().parse('$ECRMB,A,0.432,L,001,002,4653.550,N,07115.984,W,2.505,334.205,0.000,V*01')
-    delta.updates[0].values[4].value.should.be.closeTo(-800.064, 0.005)
+    delta.updates[0].values[4].value.should.be.closeTo(800.064, 0.005)
   })
 
   it('Doesn\'t choke on empty sentences', () => {


### PR DESCRIPTION
XTE.js has this

  const direction = parts[3].trim().toUpperCase() === 'L' ? 1 : -1

signalk-to-nmea0183/sentences/RMB.js has this

      return nmea.toSentence([
        '$IIRMB',
        crossTrackError.toFixed(2),
        crossTrackError < 0 ? 'R' : 'L',
        ...

RMB.js does the opposite, and produces a negative value when the required
correction is to steer left. The definition in XTE.js appears to produce the
expected result in combination with my autopiot and the NMEA2000 conversions
as well, so let's change RMB.js to match XTE.js

Signed-off-by: Ard Biesheuvel <ardb@kernel.org>