### PR TITLE
RMC now returns 'null' when field value is missing as per specification

### DIFF
--- a/hooks/RMC.js
+++ b/hooks/RMC.js
@@ -36,75 +36,68 @@ values:
  -      *6A          The checksum data, always begins with *
 */
 
-module.exports = function (parser, input) {
+module.exports = function (input) {
   const { id, sentence, parts, tags } = input
 
-  let latitude = -1
-  let longitude = -1
-  let speed = 0.0
-  let track = 0.0
-  let variation = 0.0
+  let latitude = null
+  let longitude = null
+  let speed = null
+  let track = null
+  let variation = null
 
-  try {
-    const timestamp = utils.timestamp(parts[0], parts[8])
-    const age = moment.tz(timestamp, 'UTC').unix()
+  const timestamp = utils.timestamp(parts[0], parts[8])
+  const age = moment.tz(timestamp, 'UTC').unix()
 
-    latitude = utils.coordinate(parts[2], parts[3])
-    longitude = utils.coordinate(parts[4], parts[5])
+  latitude = !isNaN(parseFloat(parts[2])) && isFinite(parts[2]) && "NS".includes(parts[3]) ? utils.coordinate(parts[2], parts[3]) : null
+  longitude =!isNaN(parseFloat(parts[4])) && isFinite(parts[4]) && "EW".includes(parts[5]) ? utils.coordinate(parts[4], parts[5]) : null
 
-    speed = utils.float(parts[6])
-    speed = (!isNaN(speed) && speed > 0) ? speed : 0.0
+  speed = !isNaN(parseFloat(parts[6])) && isFinite(parts[6]) && parts[6] >= 0 ? utils.transform(parts[6], 'knots', 'ms') : null
+  track = !isNaN(parseFloat(parts[7])) && isFinite(parts[7]) ? utils.transform(parts[7], 'deg', 'rad') : null
+  
+  variation = (!isNaN(parseFloat(parts[9])) && isFinite(parts[9]) && "EW".includes(parts[10])) ? utils.transform(utils.magneticVariaton(parts[9], parts[10]), 'deg', 'rad') : null
 
-    track = utils.float(parts[7])
-    track = (!isNaN(track)) ? track : 0.0
-
-    variation = utils.magneticVariaton(parts[9], parts[10])
-
-    const delta = {
-      updates: [
-        {
-          source: tags.source,
-          timestamp: timestamp,
-          values: [
-            {
-              path: 'navigation.position',
-              value: {
-                longitude,
-                latitude
-              }
+  const delta = {
+    updates: [
+      {
+        source: tags.source,
+        timestamp: timestamp,
+        values: [
+          {
+            path: 'navigation.position',
+            value: {
+              longitude,
+              latitude,
             },
+          },
 
-            {
-              path: 'navigation.courseOverGroundTrue',
-              value: utils.transform(track, 'deg', 'rad')
-            },
+          {
+            path: 'navigation.courseOverGroundTrue',
+            value: track,
+          },
 
-            {
-              path: 'navigation.speedOverGround',
-              value: utils.transform(speed, 'knots', 'ms')
-            },
+          {
+            path: 'navigation.speedOverGround',
+            value: speed,
+          },
 
-            {
-              path: 'navigation.magneticVariation',
-              value: utils.transform(variation, 'deg', 'rad')
-            },
+          {
+            path: 'navigation.magneticVariation',
+            value: variation,
+          },
 
-            {
-              path: 'navigation.magneticVariationAgeOfService',
-              value: age
-            },
+          {
+            path: 'navigation.magneticVariationAgeOfService',
+            value: age,
+          },
 
-            {
-              path: 'navigation.datetime',
-              value: timestamp,
-            },
-          ]
-        }
-      ],
-    }
-
-    return Promise.resolve({ delta })
-  } catch (e) {
-    return Promise.reject(e)
+          {
+            path: 'navigation.datetime',
+            value: timestamp,
+          },
+        ],
+      },
+    ],
   }
+
+  return delta
 }

--- a/hooks/VWR.js
+++ b/hooks/VWR.js
@@ -41,7 +41,7 @@ module.exports = function (parser, input) {
   const { id, sentence, parts, tags } = input
 
   const empty = parts.reduce((count, part) => { count += (isEmpty(part) ? 1 : 0); return count; }, 0)
-  if (empty > 3) {
+  if (empty > 4) {
     return Promise.resolve(null)
   }
 

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -39,10 +39,8 @@ module.exports = function parseSentence(emitter, sentence, options) {
 
   let validateChecksum = _.isUndefined(options) ||
       _.isUndefined(options.validateChecksum)  || options.validateChecksum
-  let acceptWithoutChecksum = _.isUndefined(options) ||
-      _.isUndefined(options.acceptWithoutChecksum)  || options.acceptWithoutChecksum
 
-  let valid = utils.valid(sentence, validateChecksum, acceptWithoutChecksum)
+  let valid = utils.valid(sentence, validateChecksum)
 
   if (valid === false) {
     emitter.emit('warning', { message: `Sentence "${sentence.trim()}" is invalid` })

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -39,8 +39,10 @@ module.exports = function parseSentence(emitter, sentence, options) {
 
   let validateChecksum = _.isUndefined(options) ||
       _.isUndefined(options.validateChecksum)  || options.validateChecksum
+  let acceptWithoutChecksum = _.isUndefined(options) ||
+      _.isUndefined(options.acceptWithoutChecksum)  || options.acceptWithoutChecksum
 
-  let valid = utils.valid(sentence, validateChecksum)
+  let valid = utils.valid(sentence, validateChecksum, acceptWithoutChecksum)
 
   if (valid === false) {
     emitter.emit('warning', { message: `Sentence "${sentence.trim()}" is invalid` })

--- a/test/VWR.js
+++ b/test/VWR.js
@@ -36,6 +36,21 @@ describe('VWR', () => {
     })
 
     parser.parse('$PIVWR,75,R,1.0,N,0.51,M,1.85,K*75')
+  })
+
+  it('Handles shorter valid sentences', done => {
+    const parser = new Parser
+
+    parser.on('signalk:delta', delta => {
+      delta.updates[0].values.should.contain.an.item.with.property('path', 'environment.wind.angleApparent')
+      delta.updates[0].values.should.contain.an.item.with.property('value', -0.41887902057428156)
+      delta.updates[0].values.should.contain.an.item.with.property('path', 'environment.wind.speedApparent')
+      delta.updates[0].values.should.contain.an.item.with.property('value', 9.260002345867262)
+
+
+      done()
+    })
+
     parser.parse('$IIVWR,024,L,018,N,,,,*5e')
   })
 

--- a/test/VWR.js
+++ b/test/VWR.js
@@ -16,7 +16,6 @@
 
 const Parser = require('../lib')
 const chai = require('chai')
-const nmeaLine = '$PIVWR,75,R,1.0,N,0.51,M,1.85,K*75'
 
 chai.Should()
 chai.use(require('chai-things'))
@@ -36,7 +35,8 @@ describe('VWR', () => {
       done()
     })
 
-    parser.parse(nmeaLine)
+    parser.parse('$PIVWR,75,R,1.0,N,0.51,M,1.85,K*75')
+    parser.parse('$IIVWR,024,L,018,N,,,,*5e')
   })
 
   it('Doesn\'t choke on empty sentences', done => {


### PR DESCRIPTION
Where fields were missing values RMC.js returned 0 incorrectly instead of null as per this in the specification

Under: Missing or invalid data
https://github.com/SignalK/specification/blob/c446914b331084dc5c8bcddf6aa65003b69b1c45/gitbook-docs/data_model.md#missing-or-invalid-data

eg. variation should not be set to 0.0 if RMC is field is empty.  Same goes for lat/lon and others.