### PR TITLE
change four values from int to float to match GGA sentence

### DIFF
--- a/hooks/GGA.js
+++ b/hooks/GGA.js
@@ -121,22 +121,22 @@ module.exports = function (input) {
 
           {
             path: 'navigation.gnss.antennaAltitude',
-            value: utils.int(parts[8]),
+            value: utils.float(parts[8]),
           },
 
           {
             path: 'navigation.gnss.horizontalDilution',
-            value: utils.int(parts[7]),
+            value: utils.float(parts[7]),
           },
 
           {
             path: 'navigation.gnss.geoidalSeparation',
-            value: utils.int(parts[11]),
+            value: utils.float(parts[11]),
           },
 
           {
             path: 'navigation.gnss.differentialAge',
-            value: utils.int(parts[12]),
+            value: utils.float(parts[12]),
           },
 
           {

--- a/test/GGA.js
+++ b/test/GGA.js
@@ -69,9 +69,9 @@ describe('GGA', () => {
     })
     delta.updates[0].values[1].value.should.equal('DGNSS fix')
     delta.updates[0].values[2].value.should.equal(6)
-    delta.updates[0].values[3].value.should.equal(18)
-    delta.updates[0].values[4].value.should.equal(1)
-    delta.updates[0].values[5].value.should.equal(2)
+    delta.updates[0].values[3].value.should.equal(18.893)
+    delta.updates[0].values[4].value.should.equal(1.2)
+    delta.updates[0].values[5].value.should.equal(2.0)
     delta.updates[0].values[6].value.should.equal(31)
     toFull(delta).should.be.validSignalK
   })


### PR DESCRIPTION
When horizontalDilution was < 1.0 it was being set to zero causing troubles.  3 other values (MSL Altitude ,Geoid Separation, & Age of differential GPS data) were being set to int when the GGA sentence accepts float.  