### PR TITLE
Rounding new GGA floats to 1 decimal place as SK/JS stores up to 17

### DIFF
--- a/hooks/GGA.js
+++ b/hooks/GGA.js
@@ -121,17 +121,17 @@ module.exports = function (input) {
 
           {
             path: 'navigation.gnss.antennaAltitude',
-            value: utils.float(parts[8]),
+            value: Math.round(utils.float(parts[8]) * 10) / 10 ,
           },
 
           {
             path: 'navigation.gnss.horizontalDilution',
-            value: utils.float(parts[7]),
+            value: Math.round(utils.float(parts[7]) * 10) / 10 ,
           },
 
           {
             path: 'navigation.gnss.geoidalSeparation',
-            value: utils.float(parts[11]),
+            value: Math.round(utils.float(parts[11]) * 10) / 10 ,
           },
 
           {

--- a/test/GGA.js
+++ b/test/GGA.js
@@ -69,7 +69,7 @@ describe('GGA', () => {
     })
     delta.updates[0].values[1].value.should.equal('DGNSS fix')
     delta.updates[0].values[2].value.should.equal(6)
-    delta.updates[0].values[3].value.should.equal(18.893)
+    delta.updates[0].values[3].value.should.equal(18.9)
     delta.updates[0].values[4].value.should.equal(1.2)
     delta.updates[0].values[5].value.should.equal(2.0)
     delta.updates[0].values[6].value.should.equal(31)


### PR DESCRIPTION
Seeing a few 17 place decimals in GGA, rounding to single decimal as shown in sentence description
eg. SK has:  navigation.gnss.horizontalDilution   0.7000000000000001

