### PR TITLE
feature: do not fill timestamp

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -68,10 +68,6 @@ class Parser {
       tags = {}
     }
 
-    if (typeof tags.timestamp === 'undefined') {
-      tags.timestamp = new Date().toISOString()
-    }
-
     let valid = utils.valid(sentence, this.options.validateChecksum)
 
     if (valid === false) {

--- a/test/RMB.js
+++ b/test/RMB.js
@@ -26,9 +26,8 @@ describe('RMB', () => {
     const delta = new Parser().parse(
       '$ECRMB,A,0.000,L,001,002,4653.550,N,07115.984,W,2.505,334.205,0.000,V*04'
     )
-    delta.updates[0].timestamp.should.match(
-      /[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]*)*Z/
-    )
+    should.equal(delta.updates[0].timestamp, undefined)
+    
     delta.updates[0].values.should.contain.an.item.with.property(
       'path',
       'navigation.courseRhumbline.nextPoint'


### PR DESCRIPTION
The contract of nmea0183-signalk should be to convert
source data to Signal K and only source data. If it
fills in timestamp downstream processing can not distinguish
between timestamp from source data and timestamp filled
in on the fly with current time.

Fixes #222.