### PR TITLE
fix: output null for missing COG in VTG, prefer km/h for speed

### DIFF
--- a/hooks/VTG.js
+++ b/hooks/VTG.js
@@ -62,9 +62,7 @@ module.exports = function (input) {
 
   if (utils.float(parts[6]) > 0 && String(parts[7]).toUpperCase() === 'K') {
     speed = utils.transform(utils.float(parts[6]), 'kph', 'ms')
-  }
-
-  if (utils.float(parts[4]) > 0 && String(parts[5]).toUpperCase() === 'N') {
+  } else if (utils.float(parts[4]) > 0 && String(parts[5]).toUpperCase() === 'N') {
     speed = utils.transform(utils.float(parts[4]), 'knots', 'ms')
   }
 

--- a/hooks/VTG.js
+++ b/hooks/VTG.js
@@ -76,11 +76,11 @@ module.exports = function (input) {
         values: [
           {
             path: 'navigation.courseOverGroundMagnetic',
-            value: utils.transform(utils.float(parts[2]), 'deg', 'rad'),
+            value: parts[2].length === 0 ? null : utils.transform(utils.float(parts[2]), 'deg', 'rad'),
           },
           {
             path: 'navigation.courseOverGroundTrue',
-            value: utils.transform(utils.float(parts[0]), 'deg', 'rad'),
+            value: parts[0].length === 0 ? null : utils.transform(utils.float(parts[0]), 'deg', 'rad'),
           },
           {
             path: 'navigation.speedOverGround',

--- a/test/VTG.js
+++ b/test/VTG.js
@@ -18,6 +18,7 @@
 
 const Parser = require('../lib')
 const chai = require('chai')
+const expect = chai.expect
 
 chai.Should()
 chai.use(require('chai-things'))
@@ -44,4 +45,27 @@ describe('VTG', () => {
     )
     delta.updates[0].values[2].value.should.equal(0)
   })
+
+  it('Outputs nulls for missing values', () => {
+    const delta = new Parser().parse('$GPVTG,,T,,M,0.102,N,0.190,K,A*28')
+
+    delta.updates[0].values.should.contain.an.item.with.property(
+      'path',
+      'navigation.courseOverGroundMagnetic'
+    )
+    expect(delta.updates[0].values[0].value).to.be.null
+
+    delta.updates[0].values.should.contain.an.item.with.property(
+      'path',
+      'navigation.courseOverGroundTrue'
+    )
+    expect(delta.updates[0].values[1].value).to.be.null
+
+    delta.updates[0].values.should.contain.an.item.with.property(
+      'path',
+      'navigation.speedOverGround'
+    )
+    delta.updates[0].values[2].value.should.be.closeTo(0.052, 0.0005)
+  })
+
 })

--- a/test/VTG.js
+++ b/test/VTG.js
@@ -65,7 +65,7 @@ describe('VTG', () => {
       'path',
       'navigation.speedOverGround'
     )
-    delta.updates[0].values[2].value.should.be.closeTo(0.052, 0.0005)
+    delta.updates[0].values[2].value.should.be.closeTo(0.0528, 0.00005)
   })
 
 })


### PR DESCRIPTION
FIxes #226.

Also changes conversion to use km/h for speed conversion if there is a >0 value for it. Previously that value would get converted but not used as it was overwritten with the value converted from knots.