### PR TITLE
Initial work on XDR parser

### DIFF
--- a/hooks/XDR.js
+++ b/hooks/XDR.js
@@ -1,0 +1,13 @@
+// $IIXDR,C,C,10.7,C,AIRTEMP,A,0.5,D,HEEL,A,-1.-3,D,TRIM,P,1.026,B,BARO,A,A,-4.-3,D,RUDDER*18
+
+const xdrDictionary = require('xdr-parser-plugin/xdrDict');
+const xdrParser = require('xdr-parser-plugin/xdrParser');
+
+
+module.exports = function (input) {
+  const { sentence } = input
+
+  const delta = xdrParser(sentence, xdrDictionary);
+  console.log(`Parsing ${sentence} >>> ` + JSON.stringify({ delta }, null, 2));
+  return delta
+}

--- a/hooks/XDR.js
+++ b/hooks/XDR.js
@@ -1,7 +1,7 @@
 // $IIXDR,C,C,10.7,C,AIRTEMP,A,0.5,D,HEEL,A,-1.-3,D,TRIM,P,1.026,B,BARO,A,A,-4.-3,D,RUDDER*18
 
+const math = require('math-expression-evaluator');
 const fs = require('fs');
-const xdrParser = require('xdr-parser-plugin/xdrParser');
 const xdrDictionary = { definitions: [] };
 
 // Populate a dictionary
@@ -21,7 +21,7 @@ if (fs.existsSync(xdrDictPath)) {
 xdrDictionary.definitions = [
   ...xdrDictionary.definitions,
   {
-    type: "Air temperature",
+    type: "value",
     data: "temperature",
     units: "C",
     name: "AIRTEMP",
@@ -29,17 +29,17 @@ xdrDictionary.definitions = [
     sk_path: "environment.outside.temperature",
   },
   {
-    type: "Roll",
-    data: "Angles",
-    units: "Deg",
+    type: "roll",
+    data: "angle",
+    units: "D",
     name: "HEEL",
     expression: "(x*pi/180)",
     sk_path: "navigation.attitude"
   },
   {
-    type: "Outside temperature",
-    data: "Angles",
-    units: "Deg",
+    type: "value",
+    data: "angle",
+    units: "D",
     name: "RUDDER",
     expression: "(x*pi/180)",
     sk_path: "steering.rudderAngle"
@@ -47,9 +47,110 @@ xdrDictionary.definitions = [
 ]
 
 module.exports = function (input) {
-  const { sentence } = input
+  if (!Array.isArray(xdrDictionary.definitions)) {
+    return null;
+  }
 
-  const delta = xdrParser(sentence, xdrDictionary);
-  console.log(`Parsing 4 ${sentence} >>> ` + JSON.stringify({ delta }, null, 2));
-  return delta
+  const isUpperCaseChar = (p, minLen = 0) => {
+    const num = parseFloat(p)
+    return (isNaN(num) && typeof p === 'string' && p.length > minLen && p.toUpperCase() === p)
+  }
+
+  const { definitions } = xdrDictionary
+  const { parts } = input
+  const subs = {}
+  const boundaries = parts.slice(1).filter(p => isUpperCaseChar(p, 1))
+  const values = []
+
+  for (const boundary of boundaries) {
+    const index = boundaries.indexOf(boundary);
+    const prevBoundary = index === 0 ? null : boundaries[index - 1];
+    const elements = [];
+    let fill = false;
+
+    for (p of parts.slice(1)) {
+      if (!fill && (!prevBoundary || p === prevBoundary) && elements.length === 0) {
+        fill = true;
+      }
+
+      if (fill === false || p === boundary) {
+        fill = false;
+        continue
+      }
+
+      if (p !== prevBoundary) {
+        elements.push(p);
+      }
+    }
+
+    if (elements.length) {
+      subs[boundary] = elements
+    }
+  }
+
+  for (const boundary of boundaries) {
+    const data = subs[boundary]
+
+    let typeFlag = null
+    let value = null
+    let unit = null
+    
+    if (data.length === 3) {
+      ([ typeFlag, value, unit ] = data);
+    }
+
+    if (value === null || typeFlag === null || unit === null) {
+      continue
+    }
+
+    if (isNaN(parseFloat(value))) {
+      continue
+    }
+
+    const def = definitions.find(({ name }) => (name === boundary));
+
+    if (!def) {
+      continue;
+    }
+
+    if (def.units !== unit) {
+      // Not parsing as unit doesn't match
+      continue;
+    }
+
+    const expression = def.expression.replace(/x/g, value); 
+    const attitudeTypes = ['yaw', 'pitch', 'roll'];
+
+    let path = def.sk_path;
+    let result = math.eval(expression); 
+
+    if (!result || isNaN(result)) {
+      continue
+    }
+
+    result = parseFloat(result.toFixed(4))
+
+    if (attitudeTypes.includes(def.type.toLowerCase())) {
+      path = `${path}.${def.type}`
+    }
+
+    values.push({
+      path,
+      value: result
+    })
+  }
+
+  if (values.length === 0) {
+    return null;
+  }
+
+  return {
+    updates: [
+      {
+        source: 'XDR',
+        timestamp: new Date().toISOString(),
+        values,
+      },
+    ],
+  }
 }

--- a/hooks/XDR.js
+++ b/hooks/XDR.js
@@ -27,6 +27,22 @@ xdrDictionary.definitions = [
     name: "AIRTEMP",
     expression: "(x+273.15)",
     sk_path: "environment.outside.temperature",
+  },
+  {
+    type: "Roll",
+    data: "Angles",
+    units: "Deg",
+    name: "HEEL",
+    expression: "(x*pi/180)",
+    sk_path: "navigation.attitude"
+  },
+  {
+    type: "Outside temperature",
+    data: "Angles",
+    units: "Deg",
+    name: "RUDDER",
+    expression: "(x*pi/180)",
+    sk_path: "steering.rudderAngle"
   }
 ]
 

--- a/hooks/XDR.js
+++ b/hooks/XDR.js
@@ -4,18 +4,22 @@ const math = require('math-expression-evaluator');
 const fs = require('fs');
 const xdrDictionary = { definitions: [] };
 
-// Populate a dictionary
-const xdrDictPath = require.resolve('xdr-parser-plugin/xdrDict');
-if (fs.existsSync(xdrDictPath)) {
-  try {
-    const json = JSON.parse(fs.readFileSync(xdrDictPath, 'utf-8'));
+try {
+  // Populate a dictionary
+  const xdrDictPath = require.resolve('xdr-parser-plugin/xdrDict');
+  if (fs.existsSync(xdrDictPath)) {
+    try {
+      const json = JSON.parse(fs.readFileSync(xdrDictPath, 'utf-8'));
 
-    if (json && Array.isArray(json.definitions)) {
-      xdrDictionary.definitions = [ ...json.definitions ];
+      if (json && Array.isArray(json.definitions)) {
+        xdrDictionary.definitions = [ ...json.definitions ];
+      }
+    } catch (err) {
+      console.warn('No dictionary found for xdr-parser-plugin');
     }
-  } catch (err) {
-    console.warn('No dictionary found for xdr-parser-plugin');
   }
+} catch (e) {
+  console.warn('Using default dictionary');
 }
 
 xdrDictionary.definitions = [

--- a/hooks/XDR.js
+++ b/hooks/XDR.js
@@ -18,6 +18,18 @@ if (fs.existsSync(xdrDictPath)) {
   }
 }
 
+xdrDictionary.definitions = [
+  ...xdrDictionary.definitions,
+  {
+    type: "Air temperature",
+    data: "temperature",
+    units: "C",
+    name: "AIRTEMP",
+    expression: "(x+273.15)",
+    sk_path: "environment.outside.temperature",
+  }
+]
+
 module.exports = function (input) {
   const { sentence } = input
 

--- a/hooks/XDR.js
+++ b/hooks/XDR.js
@@ -50,6 +50,6 @@ module.exports = function (input) {
   const { sentence } = input
 
   const delta = xdrParser(sentence, xdrDictionary);
-  console.log(`Parsing ${sentence} >>> ` + JSON.stringify({ delta }, null, 2));
+  console.log(`Parsing 4 ${sentence} >>> ` + JSON.stringify({ delta }, null, 2));
   return delta
 }

--- a/hooks/XDR.js
+++ b/hooks/XDR.js
@@ -1,8 +1,22 @@
 // $IIXDR,C,C,10.7,C,AIRTEMP,A,0.5,D,HEEL,A,-1.-3,D,TRIM,P,1.026,B,BARO,A,A,-4.-3,D,RUDDER*18
 
-const xdrDictionary = require('xdr-parser-plugin/xdrDict');
+const fs = require('fs');
 const xdrParser = require('xdr-parser-plugin/xdrParser');
+const xdrDictionary = { definitions: [] };
 
+// Populate a dictionary
+const xdrDictPath = require.resolve('xdr-parser-plugin/xdrDict');
+if (fs.existsSync(xdrDictPath)) {
+  try {
+    const json = JSON.parse(fs.readFileSync(xdrDictPath, 'utf-8'));
+
+    if (json && Array.isArray(json.definitions)) {
+      xdrDictionary.definitions = [ ...json.definitions ];
+    }
+  } catch (err) {
+    console.warn('No dictionary found for xdr-parser-plugin');
+  }
+}
 
 module.exports = function (input) {
   const { sentence } = input

--- a/hooks/index.js
+++ b/hooks/index.js
@@ -40,4 +40,5 @@ module.exports = {
   BWC: require('./BWC.js'),
   BWR: require('./BWR.js'),
   HSC: require('./HSC.js'),
+  XDR: require('./XDR.js'),
 }

--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
     "ggencoder": "^1.0.4",
     "math-expression-evaluator": "^1.4.0",
     "moment-timezone": "^0.5.21",
-    "split": "^1.0.1",
-    "xdr-parser-plugin": "^1.0.5"
+    "split": "^1.0.1"
   },
   "devDependencies": {
     "@signalk/github-create-release": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "@signalk/signalk-schema": "1.6.0",
     "ggencoder": "^1.0.4",
     "moment-timezone": "^0.5.21",
-    "split": "^1.0.1"
+    "split": "^1.0.1",
+    "xdr-parser-plugin": "^1.0.5"
   },
   "devDependencies": {
     "@signalk/github-create-release": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@signalk/nmea0183-utilities": "^0.8.0",
     "@signalk/signalk-schema": "1.6.0",
     "ggencoder": "^1.0.4",
+    "math-expression-evaluator": "^1.4.0",
     "moment-timezone": "^0.5.21",
     "split": "^1.0.1",
     "xdr-parser-plugin": "^1.0.5"

--- a/test/XDR.js
+++ b/test/XDR.js
@@ -1,0 +1,27 @@
+// $IIXDR,C,C,10.7,C,AIRTEMP,A,0.5,D,HEEL,A,-1.-3,D,TRIM,P,1.026,B,BARO,A,A,-4.-3,D,RUDDER*18
+
+const Parser = require('../lib')
+
+const chai = require('chai')
+const expect = chai.expect
+
+chai.Should()
+chai.use(require('chai-things'))
+
+describe('XDR', () => {
+  it('Converts OK using individual parser', () => {
+    const delta = new Parser().parse('$IIXDR,C,C,10.7,C,AIRTEMP,A,0.5,D,HEEL,A,-1.-3,D,TRIM,P,1.026,B,BARO,A,A,-4.-3,D,RUDDER*18')
+    
+    delta.updates[0].values.should.contain.an.item.with.property(
+      'path',
+      'environment.outside.temperature'
+    )
+    delta.updates[0].values[0].value.should.be.closeTo(283.85, 0.005)
+
+    delta.updates[0].values.should.contain.an.item.with.property(
+      'path',
+      'navigation.attitude.roll'
+    )
+    delta.updates[0].values[1].value.should.be.closeTo(0.0087, 0.00005)
+  })
+})


### PR DESCRIPTION
This PR implements an initial implementation for an XDR parser that uses the definitions format from `xdr-parser-plugin`. The implementation is different however, as that plugin has several issues IMO (e.g. `require` statements within function bodies). 

In order to finish this PR, it would make sense (to me) to internalise the dictionary of XDR sentences rather tha pulling it from `xdr-parser-plugin`, and expanding on the definitions in there. Also, it would make sense to make the expression dependent on the unit (RN I'm simply checking if the units match). 