### PR TITLE
Added support for ShipModul Miniplex Latest Firmware

### DIFF
--- a/hooks/proprietary/PSMDST.js
+++ b/hooks/proprietary/PSMDST.js
@@ -22,7 +22,7 @@
 $PSMDST,Z,xx,yy,nn*CS
 where:
 PSMDST     	Raymarine Seatalk1 datagram sentence
-0       C/R       R for Recevied messages, C for sent messages
+0       C/R       R for Recevied messages, C for sent messages *Note: This field only exists in later firmware versions of the ShipModul Miniplex
 1 			00-9C     Datagram type
 2 			hex       First datagram content
 3 			hex   		Last datagram content
@@ -33,8 +33,10 @@ const seatalkHooks = require('../seatalk')
 
 module.exports = function (input, session) {
   const { id, sentence, parts, tags } = input
-  const key = '0x' + parts[1].toUpperCase();
-  input.parts = parts.slice(1, input.parts.length);
+  if (parts[0].toUpperCase() === 'R') {
+    input.parts = parts.slice(1, input.parts.length);
+  }
+  const key = '0x' + input.parts[0].toUpperCase();
   if (typeof seatalkHooks[key] === 'function') {
     return seatalkHooks[key](input, session)
   } else {

--- a/hooks/proprietary/PSMDST.js
+++ b/hooks/proprietary/PSMDST.js
@@ -22,7 +22,7 @@
 $PSMDST,Z,xx,yy,nn*CS
 where:
 0       PSMDST     	Raymarine Seatalk1 datagram sentence
-1       C/R       R for Recevied messages, C for sent messages *Note: This field only exists in later firmware versions of the ShipModul Miniplex
+1       C/R       R for Received messages, C for sent messages *Note: This field only exists in later firmware versions of the ShipModul Miniplex
 2 			00-9C     Datagram type
 3 			hex       First datagram content
 4 			hex   		Last datagram content

--- a/hooks/proprietary/PSMDST.js
+++ b/hooks/proprietary/PSMDST.js
@@ -17,22 +17,24 @@
 'use strict'
 
 /*
-0  1  2  3
-|  |  |  |
-$PSMDST,xx,yy,nn*CS
+0  1  2  3  4
+|  |  |  |  |
+$PSMDST,Z,xx,yy,nn*CS
 where:
 PSMDST     	Raymarine Seatalk1 datagram sentence
-0 			00-9C       	Datagram type
-1 			hex       	First datagram content
-2 			hex   		Last datagram content
-3 			hex      	Checksum
+0       C/R       R for Recevied messages, C for sent messages
+1 			00-9C     Datagram type
+2 			hex       First datagram content
+3 			hex   		Last datagram content
+4 			hex      	Checksum
 */
 
 const seatalkHooks = require('../seatalk')
 
 module.exports = function (input, session) {
   const { id, sentence, parts, tags } = input
-  const key = '0x' + parts[0].toUpperCase()
+  const key = '0x' + parts[1].toUpperCase();
+  input.parts = parts.slice(1, input.parts.length);
   if (typeof seatalkHooks[key] === 'function') {
     return seatalkHooks[key](input, session)
   } else {

--- a/hooks/proprietary/PSMDST.js
+++ b/hooks/proprietary/PSMDST.js
@@ -17,16 +17,16 @@
 'use strict'
 
 /*
-0  1  2  3  4
-|  |  |  |  |
+0       1 2  3  4  5
+|       | |  |  |  |
 $PSMDST,Z,xx,yy,nn*CS
 where:
-PSMDST     	Raymarine Seatalk1 datagram sentence
-0       C/R       R for Recevied messages, C for sent messages *Note: This field only exists in later firmware versions of the ShipModul Miniplex
-1 			00-9C     Datagram type
-2 			hex       First datagram content
-3 			hex   		Last datagram content
-4 			hex      	Checksum
+0       PSMDST     	Raymarine Seatalk1 datagram sentence
+1       C/R       R for Recevied messages, C for sent messages *Note: This field only exists in later firmware versions of the ShipModul Miniplex
+2 			00-9C     Datagram type
+3 			hex       First datagram content
+4 			hex   		Last datagram content
+5 			hex      	Checksum
 */
 
 const seatalkHooks = require('../seatalk')

--- a/test/seatalk.js
+++ b/test/seatalk.js
@@ -53,7 +53,7 @@ const should = chai.Should()
 chai.use(require('chai-things'))
 
 describe('seatalk', () => {
-  ;['$PSMDST,', '$PSMDST,R,', '$STALK,'].forEach((prefix) => {
+  ;['$PSMDST,', '$PSMDST_R,', '$STALK,'].forEach((prefix) => {
     it(`${prefix} 0x00 depth converted`, () => {
       const fullSentence = utils.appendChecksum(`${prefix}${depthData}`)
       const delta = new Parser().parse(fullSentence)

--- a/test/seatalk.js
+++ b/test/seatalk.js
@@ -53,7 +53,7 @@ const should = chai.Should()
 chai.use(require('chai-things'))
 
 describe('seatalk', () => {
-  ;['$PSMDST', '$PSMDST_R', '$STALK,'].forEach((prefix) => {
+  ;['$PSMDST,', '$PSMDST,R,', '$STALK,'].forEach((prefix) => {
     it(`${prefix} 0x00 depth converted`, () => {
       const fullSentence = utils.appendChecksum(`${prefix}${depthData}`)
       const delta = new Parser().parse(fullSentence)

--- a/test/seatalk.js
+++ b/test/seatalk.js
@@ -53,7 +53,7 @@ const should = chai.Should()
 chai.use(require('chai-things'))
 
 describe('seatalk', () => {
-  ;['$PSMDST,R,', '$STALK,'].forEach((prefix) => {
+  ;['$PSMDST', '$PSMDST_R', '$STALK,'].forEach((prefix) => {
     it(`${prefix} 0x00 depth converted`, () => {
       const fullSentence = utils.appendChecksum(`${prefix}${depthData}`)
       const delta = new Parser().parse(fullSentence)

--- a/test/seatalk.js
+++ b/test/seatalk.js
@@ -53,7 +53,7 @@ const should = chai.Should()
 chai.use(require('chai-things'))
 
 describe('seatalk', () => {
-  ;['$PSMDST,', '$STALK,'].forEach((prefix) => {
+  ;['$PSMDST,R,', '$STALK,'].forEach((prefix) => {
     it(`${prefix} 0x00 depth converted`, () => {
       const fullSentence = utils.appendChecksum(`${prefix}${depthData}`)
       const delta = new Parser().parse(fullSentence)

--- a/test/seatalk.js
+++ b/test/seatalk.js
@@ -53,7 +53,7 @@ const should = chai.Should()
 chai.use(require('chai-things'))
 
 describe('seatalk', () => {
-  ;['$PSMDST,', '$PSMDST_R,', '$STALK,'].forEach((prefix) => {
+  ;['$PSMDST,', '$PSMDST,R,', '$STALK,'].forEach((prefix) => {
     it(`${prefix} 0x00 depth converted`, () => {
       const fullSentence = utils.appendChecksum(`${prefix}${depthData}`)
       const delta = new Parser().parse(fullSentence)


### PR DESCRIPTION
The ShipModul Miniplex has added a field to the PSMDST message to indicate sending to 'C' or receiving from 'R' the SeaTalk network. This change adds support for the new field by looking for the 'R' field then parsing the data accordingly. 