### PR TITLE
fix: HDG deviation handling

### DIFF
--- a/hooks/HDG.js
+++ b/hooks/HDG.js
@@ -39,21 +39,48 @@ function isEmpty(mixed) {
 }
 
 module.exports = function (input) {
-  const { id, sentence, parts, tags } = input
-
+  const { parts, tags } = input
   const values = []
-  if (!isEmpty(parts[0])) {
+
+  const headingCompass = parts[0]
+  const deviation = parts[1]
+  const deviationDir = parts[2] === 'E' ? 1 : -1
+  const variation = parts[3]
+  const variationDir = parts[4] === 'E' ? 1 : -1
+  if (!isEmpty(headingCompass)) {
+    const effectiveDeviation = !isEmpty(deviation) ? Number(deviation) * deviationDir : 0
     values.push({
       path: 'navigation.headingMagnetic',
-      value: utils.transform(utils.float(parts[0]), 'deg', 'rad'),
+      value: utils.transform(utils.float(headingCompass) + effectiveDeviation, 'deg', 'rad'),
     })
+    if (!isEmpty(deviation)) {
+      values.push({
+        path: 'navigation.headingCompass',
+        value: utils.transform(utils.float(headingCompass), 'deg', 'rad'),
+      })  
+    }
+    if (!isEmpty(variation)) {
+      const effectiveVariation = variation * variationDir
+      values.push({
+        path: 'navigation.headingTrue',
+        value: utils.transform(utils.float(headingCompass) + effectiveDeviation + effectiveVariation, 'deg', 'rad'),
+      })  
+    }
   }
-  if (!(isEmpty(parts[3]) || isEmpty(parts[4]))) {
+  if (!(isEmpty(variation) || isEmpty(variationDir))) {
     values.push({
       path: 'navigation.magneticVariation',
       value:
-        utils.transform(utils.float(parts[3]), 'deg', 'rad') *
-        (parts[4] === 'E' ? 1 : -1),
+        utils.transform(utils.float(variation), 'deg', 'rad') *
+        variationDir,
+    })
+  }
+  if (!(isEmpty(deviation) || isEmpty(deviationDir))) {
+    values.push({
+      path: 'navigation.magneticDeviation',
+      value:
+        utils.transform(utils.float(deviation), 'deg', 'rad') *
+        deviationDir,
     })
   }
   if (!values.length) {

--- a/test/HDG.js
+++ b/test/HDG.js
@@ -35,10 +35,9 @@ describe('HDG', () => {
       'path',
       'navigation.magneticVariation'
     )
-    delta.updates[0].values[1].value.should.be.closeTo(
-      (0.6 / 180) * Math.PI,
-      0.005
-    )
+    delta.updates[0].values
+      .find((pv) => pv.path === 'navigation.magneticVariation')
+      .value.should.be.closeTo((0.6 / 180) * Math.PI, 0.005)
   })
 
   it('Sentence with just heading works', () => {
@@ -52,6 +51,26 @@ describe('HDG', () => {
       (51.5 / 180) * Math.PI,
       0.005
     )
+  })
+
+  it('Sentence with all fields converts and applies corrections', () => {
+    const delta = new Parser().parse('$INHDG,180,5,W,10,W*6D')
+
+    delta.updates[0].values
+      .find((pv) => pv.path === 'navigation.headingMagnetic')
+      .value.should.be.closeTo(((180 - 5) / 180) * Math.PI, 0.00001)
+    delta.updates[0].values
+      .find((pv) => pv.path === 'navigation.headingCompass')
+      .value.should.be.closeTo((180 / 180) * Math.PI, 0.00001)
+    delta.updates[0].values
+      .find((pv) => pv.path === 'navigation.magneticVariation')
+      .value.should.be.closeTo((-10 / 180) * Math.PI, 0.00001)
+    delta.updates[0].values
+      .find((pv) => pv.path === 'navigation.magneticDeviation')
+      .value.should.be.closeTo((-5 / 180) * Math.PI, 0.00001)
+    delta.updates[0].values
+      .find((pv) => pv.path === 'navigation.headingTrue')
+      .value.should.be.closeTo(((180 - 5 - 10) / 180) * Math.PI, 0.00001)
   })
 
   it("Doesn't choke on empty sentences", () => {


### PR DESCRIPTION
Fixes #235.

Previously deviation was not handled at all. Now if there is deviation it is applied to create nav.headingMagnetic and in addition nav.headingCompass is output. This PR also adds deviation to the output.

If there is no deviation value the output is as previously: the sensor value in the first field is output as is as nav.headingMagnetic and no nav.headingCompass. This is a bit backwards, as what is being output is nav.headingCompass, but I think changing that would warrant a major version change for being so incompatible with the current behavior.

If the sentence includes variation also nav.headingTrue is output.