### PR TITLE
fix: ST 0x25 log calculation

### DIFF
--- a/hooks/seatalk/0x25.js
+++ b/hooks/seatalk/0x25.js
@@ -18,35 +18,37 @@
 
 const utils = require('@signalk/nmea0183-utilities')
 
+
 /*
+https://github.com/mariokonrad/marnav/blob/01c55205736fcc8157891b84e3efe387a221ff3a/src/marnav/seatalk/message_25.cpp#L21-L26
 25  Z4  XX  YY  UU  VV AW  Total & Trip Log 
-                      total= (XX+YY*256+Z* 4096)/ 10 [max=104857.5] nautical miles
+                      total= (XX+YY*256+Z* 65536)/ 10 [max=104857.5] nautical miles
                       trip = (UU+VV*256+W*65536)/100 [max=10485.75] nautical miles
 */
 
 module.exports = function (input) {
   const { id, sentence, parts, tags } = input
 
-  var Z = (parseInt(parts[1], 16) & 0xf0) >> 4
+  var Z = parseInt(parts[1], 16) >> 4
   var XX = parseInt(parts[2], 16)
   var YY = parseInt(parts[3], 16)
   var UU = parseInt(parts[4], 16)
   var VV = parseInt(parts[5], 16)
   var W = parseInt(parts[6], 16) & 0x0f
 
-  var total = (XX + YY * 256 + Z * 4096) / 10.0
+  var total = (XX + YY * 256 + Z * 65536) / 10.0
   var trip = (UU + VV * 256 + W * 65536) / 100.0
 
   var pathValues = []
 
   pathValues.push({
     path: 'navigation.trip',
-    value: utils.transform(utils.float(trip), 'nm', 'km') * 1000,
+    value: utils.transform(utils.float(trip), 'nm', 'm'),
   })
 
   pathValues.push({
     path: 'navigation.log',
-    value: utils.transform(utils.float(total), 'nm', 'km') * 1000,
+    value: utils.transform(utils.float(total), 'nm', 'm'),
   })
 
   return {

--- a/test/seatalk.js
+++ b/test/seatalk.js
@@ -132,7 +132,17 @@ describe('seatalk', () => {
       delta.updates[0].values[0].value.should.be.closeTo(4086808.4, 0.5)
     })
 
-    it(`${prefix} 0x25 trip and log converted`, () => {
+    it(`${prefix} 0x25 trip and log converted 2`, () => {
+      const fullSentence = utils.appendChecksum(`${prefix}25,14,4C,BF,00,00,00}`)
+      const delta = new Parser().parse(fullSentence)
+      delta.updates[0].values.should.contain.an.item.with.property(
+        'path',
+        'navigation.log'
+      )
+      delta.updates[0].values[1].value.should.be.closeTo(utils.transform(11450.8, 'nm', 'm'), 0.5)
+    })
+
+    it(`${prefix} 0x25 trip and log converted 1`, () => {
       const fullSentence = utils.appendChecksum(`${prefix}${tripAndLogData}`)
       const delta = new Parser().parse(fullSentence)
       delta.updates[0].values.should.contain.an.item.with.property(
@@ -144,7 +154,7 @@ describe('seatalk', () => {
         'path',
         'navigation.log'
       )
-      delta.updates[0].values[1].value.should.be.closeTo(7035562.8, 0.5)
+      delta.updates[0].values[1].value.should.be.closeTo(52550314.8, 0.5)
     })
 
     it(`${prefix} 0x26 STW converted`, () => {


### PR DESCRIPTION
Fix the formula for calculating ST 0x25 datagram total log.

These are equivalent:
```
- >> 4 and multiply by 65536
- zero out the 8 least significant bits and multiply by 4096
```

but not both >>4 and multiply by 4096 that it was doing.

Fixes #248.