### PR TITLE
Fix: convert salinity and relativeHumidity  in VDM from percentage values to ratio

### DIFF
--- a/hooks/VDM.js
+++ b/hooks/VDM.js
@@ -25,6 +25,7 @@ const knotsToMs = (v) =>
 const degToRad = (v) => utils.transform(v, 'deg', 'rad')
 const cToK = (v) => parseFloat(utils.transform(v, 'c', 'k').toFixed(2))
 const nmToM = (v) => parseFloat(utils.transform(v, 'nm', 'm').toFixed(2))
+const percentToRatio = (v) => v / 100
 
 const stateMapping = {
   0: 'motoring',
@@ -326,7 +327,7 @@ module.exports = function (input, session) {
     ['winddir', 'wind.directionTrue', degToRad],
     ['windgustdir', 'wind.gustDirectionTrue', degToRad],
     ['airtemp', 'outside.temperature', cToK],
-    ['relhumid', 'outside.relativeHumidity', (v) => v],
+    ['relhumid', 'outside.relativeHumidity', percentToRatio],
     ['dewpoint', 'outside.dewPointTemperature', cToK],
     ['airpress', 'outside.pressure', (v) => v * 100],
     ['waterlevel', 'water.level', (v) => v],
@@ -337,7 +338,7 @@ module.exports = function (input, session) {
     ['swellperiod', 'water.swell.period', (v) => v],
     ['swelldir', 'water.swell.directionTrue', degToRad],
     ['watertemp', 'water.temperature', cToK],
-    ['salinity', 'water.salinity', (v) => v],
+    ['salinity', 'water.salinity', percentToRatio],
     ['surfcurrspd', 'water.current.drift', knotsToMs],
     ['surfcurrdir', 'water.current.set', degToRad],
   ].forEach(([propName, path, f]) => {

--- a/test/VDM.js
+++ b/test/VDM.js
@@ -244,11 +244,12 @@ describe('VDM', function () {
     )
     delta.context.should.equal('meteo.urn:mrn:imo:mmsi:002655619:366097')
     const currentYear = new Date().getFullYear();
+    const currentMonth = ('00' + (new Date().getMonth()+1)).slice(-2);
     const output = [
       ['environment.water.level', -0.17],
       ['environment.water.levelTendency', 'steady'],
       ['environment.water.levelTendencyValue', 0],
-      ['environment.date', currentYear + '-02-22T15:42:00.000Z']
+      ['environment.date', `${currentYear}-${currentMonth}-22T15:42:00.000Z`]
     ]
     output.forEach(([path, value]) =>
       delta.updates[0].values
@@ -270,6 +271,7 @@ describe('VDM', function () {
     delta.updates[0].values[3].value.longitude.should.equal(11.7283)
     delta.updates[0].values[3].value.latitude.should.equal(57.9669)
     const currentYear = new Date().getFullYear()
+    const currentMonth = ('00' + (new Date().getMonth()+1)).slice(-2);
     const output = [
       ['sensors.ais.designatedAreaCode', 1],
       ['sensors.ais.functionalId', 31],
@@ -277,7 +279,7 @@ describe('VDM', function () {
       ['environment.wind.gust', 11.32],
       ['environment.wind.directionTrue', 4.817108736604238],
       ['environment.wind.gustDirectionTrue', 4.817108736604238],
-      ['environment.date', currentYear + '-02-20T14:47:00.000Z'],
+      ['environment.date', `${currentYear}-${currentMonth}-20T14:47:00.000Z`],
     ]
     output.forEach(([path, value]) =>
       delta.updates[0].values


### PR DESCRIPTION
**Issue:** (#253)
`salinity` and `relativeHumidity` paths in the specification (`environment` group) are defined with the unit `ratio`.

Values from the VDM sentence are written to these signal K paths as a number representing a percentage (e.g. 80) rather than a ratio (i.e. 0.8).

This PR converts the received values to a ratio so they align with the specification. 

