### PR TITLE
Fix: not sending delta when next position values are missing

### DIFF
--- a/hooks/BWC.js
+++ b/hooks/BWC.js
@@ -66,6 +66,11 @@ module.exports = function BWCHook(input) {
         latitude,
       },
     })
+  } else {
+    values.push({
+      path: 'navigation.courseGreatCircle.nextPoint.position',
+      value: null,
+    })
   }
 
   if (parts[9] !== '' && parts[10] !== '') {

--- a/hooks/RMB.js
+++ b/hooks/RMB.js
@@ -20,7 +20,7 @@ const utils = require('@signalk/nmea0183-utilities')
 const moment = require('moment-timezone')
 
 /*
-RMC Sentence
+RMB Sentence
 $GPRMB,A,0.66,L,003,004,4917.24,N,12309.57,W,001.3,052.5,000.5,V*20
 values:
 
@@ -49,11 +49,17 @@ module.exports = function (input) {
   let vmg = 0.0
   let distance = 0.0
   let crossTrackError = 0.0
+  let position = null
 
   latitude = utils.coordinate(parts[5], parts[6])
   longitude = utils.coordinate(parts[7], parts[8])
   if (isNaN(latitude) || isNaN(longitude)) {
-    return null
+    position = null
+  } else {
+    position = {
+      longitude,
+      latitude
+    }
   }
 
   bearing = utils.float(parts[10])
@@ -78,10 +84,7 @@ module.exports = function (input) {
         values: [
           {
             path: 'navigation.courseRhumbline.nextPoint.position',
-            value: {
-              longitude,
-              latitude,
-            },
+            value: position,
           },
 
           {

--- a/test/BWC.js
+++ b/test/BWC.js
@@ -64,6 +64,10 @@ describe('BWC', () => {
     delta.should.be.an('object')
     delta.updates[0].values.should.deep.equal([
       {
+        path: 'navigation.courseGreatCircle.nextPoint.position',
+        value: null,
+      },
+      {
         path: 'navigation.courseGreatCircle.nextPoint.distance',
         value: 40929.20003454424,
       },
@@ -80,6 +84,12 @@ describe('BWC', () => {
 
   it("Doesn't choke on an empty sentence", () => {
     const delta = new Parser().parse('$GPBWC,,,,,,,,,,,,*41')
-    should.equal(delta, undefined)
+
+    delta.updates[0].values.should.deep.equal([
+      {
+        path: 'navigation.courseGreatCircle.nextPoint.position',
+        value: null,
+      },
+    ])
   })
 })

--- a/test/BWR.js
+++ b/test/BWR.js
@@ -56,6 +56,20 @@ describe('BWR', () => {
 
   it("Doesn't choke on an empty sentence", () => {
     const delta = new Parser().parse('$GPBWR,,,,,,,,,,,,*50')
-    should.equal(delta, null)
+    delta.updates[0].values.should.deep.equal([
+      { path: 'navigation.courseRhumbline.bearingTrackTrue', value: null },
+      {
+        path: 'navigation.courseRhumbline.bearingTrackMagnetic',
+        value: null,
+      },
+      {
+        path: 'navigation.courseRhumbline.nextPoint.distance',
+        value: null,
+      },
+      {
+        path: 'navigation.courseRhumbline.nextPoint.position',
+        value: null,
+      },
+    ])
   })
 })

--- a/test/RMB.js
+++ b/test/RMB.js
@@ -75,6 +75,9 @@ describe('RMB', () => {
 
   it("Doesn't choke on empty sentences", () => {
     const delta = new Parser().parse('$ECRMB,,,,,,,,,,,,,*77')
-    should.equal(delta, null)
+    delta.updates[0].values.should.contain.an.item.with.property(
+      'path',
+      'navigation.courseRhumbline.nextPoint.position'
+    )
   })
 })

--- a/test/RMB.js
+++ b/test/RMB.js
@@ -79,5 +79,10 @@ describe('RMB', () => {
       'path',
       'navigation.courseRhumbline.nextPoint.position'
     )
+    delta.updates[0].values.should.contain.an.item({
+      path: 'navigation.courseRhumbline.nextPoint.position',
+      value: null
+    })
   })
+
 })


### PR DESCRIPTION
Fix RMB, BWC and BWR sentence processing behaviour to send a delta when position field values are missing.

**_Current behaviour:_**
Whe position field values are missing, function does not return data and no delta is sent.
This means that clients are left unaware of a previously active destination being "de-activated" and will continue to show the destination as active.

**_FIx:_**
When position field values are missing, return data so that a delta is sent with `nextPoint.position` value = null.