### PR TITLE
fix: output null for empty MTA (air) or MTW (water) temperature.

### DIFF
--- a/hooks/MTA.js
+++ b/hooks/MTA.js
@@ -27,7 +27,7 @@ const utils = require('@signalk/nmea0183-utilities')
  *
  * Field Number:
  *   0.    Degrees
- *   1.    Unit of Measurement, Celcius
+ *   1.    Unit of Measurement, Celsius
  *   2.    Checksum
  *
  */
@@ -46,7 +46,7 @@ module.exports = function (input) {
         values: [
           {
             path: 'environment.outside.temperature',
-            value: utils.transform(utils.float(parts[0]), 'c', 'k'),
+            value: parts.length > 0 && parts[0].trim().length > 0 ? utils.transform(utils.float(parts[0]), 'c', 'k') : null,
           },
         ],
       },

--- a/hooks/MTW.js
+++ b/hooks/MTW.js
@@ -27,7 +27,7 @@ const utils = require('@signalk/nmea0183-utilities')
  *
  * Field Number:
  *   0.    Degrees
- *   1.    Unit of Measurement, Celcius
+ *   1.    Unit of Measurement, Celsius
  *   2.    Checksum
  *
  */
@@ -43,8 +43,7 @@ module.exports = function (input) {
         values: [
           {
             path: 'environment.water.temperature',
-            value: utils.transform(utils.float(parts[0]), 'c', 'k'),
-            //returns raw value, no transformation done
+            value: parts.length > 0 && parts[0].trim().length > 0 ? utils.transform(utils.float(parts[0]), 'c', 'k') : null,
           },
         ],
       },

--- a/test/MTA.js
+++ b/test/MTA.js
@@ -37,4 +37,13 @@ describe('MTA', () => {
 
     should.equal(delta, null)
   })
+
+  it('Converts empty value to null', () => {
+    const delta = new Parser().parse('$RAMTA,,C*08')
+    delta.updates[0].values.length.should.equal(1)
+    delta.updates[0].values[0].path.should.equal(
+      'environment.outside.temperature'
+    )
+    chai.expect(delta.updates[0].values[0].value).to.be.null
+  })
 })

--- a/test/MTW.js
+++ b/test/MTW.js
@@ -32,4 +32,13 @@ describe('MTW', () => {
     )
     delta.updates[0].values[0].value.should.be.closeTo(288.35, 0.005)
   })
+
+  it('Converts empty value to null', () => {
+    const delta = new Parser().parse('$RAMTW,,C*1E')
+    delta.updates[0].values.length.should.equal(1)
+    delta.updates[0].values[0].path.should.equal(
+      'environment.water.temperature'
+    )
+    chai.expect(delta.updates[0].values[0].value).to.be.null
+  })
 })


### PR DESCRIPTION
Empty values like in '$RAMTW,,C*1E' are now converted to 0 degrees Celsius (or 273.15K). 
This is incorrect and also not in line with similar cases in for depth data (DPT, DBK).