### PR TITLE
Fix 0x85 distance field byte order

### DIFF
--- a/hooks/seatalk/0x85.js
+++ b/hooks/seatalk/0x85.js
@@ -102,10 +102,11 @@ module.exports = function (input) {
   }
 
   // Distance to destination
-  // ZZZ is formed from Z_high (high nibble of byte 4) and ZZ (byte 5)
+  // ZZZ is formed from ZZ (byte 5) and Z_high (high nibble of byte 4)
+  // Byte order is low-nibble-last: ZZZ = (ZZ << 4) | Z_high
   const rangePresent = (F & 0x4) === 0x4
   if (rangePresent) {
-    const ZZZ = (Z_high << 8) | ZZ
+    const ZZZ = (ZZ << 4) | Z_high
     // If Y & 1 = 1: ZZZ / 100 nm (0-9.99nm)
     // If Y & 1 = 0: ZZZ / 10 nm (≥10nm)
     const distanceNm = (Y & 0x1) === 0x1 ? ZZZ / 100 : ZZZ / 10

--- a/test/seatalk.js
+++ b/test/seatalk.js
@@ -50,11 +50,11 @@ const heading_nineCData = '9C,51,1E,00'
 const empty_nineCData = '9C,,,'
 const empty_eightFourData = '84,,,,,,,,'
 // 0x85 Navigation to waypoint: XTE=1.00nm steer left, bearing=45° magnetic, distance=5.50nm
-const navToWaypointData = '85,06,64,02,05,96,17,00,00'
+const navToWaypointData = '85,06,64,A0,65,22,17,00,00'
 // 0x85 Navigation to waypoint with true bearing: XTE=0.50nm steer right, bearing=180° true, distance=12.0nm
 // F=0x07 means XTE present (bit 0), bearing present (bit 1), range present (bit 2)
 // U=0xA means (A & 0x3)*90 = 2*90 = 180° base, and (A & 0x8) = 0x8 so True bearing
-const navToWaypointTrueData = '85,06,32,0A,07,78,07,00,00'
+const navToWaypointTrueData = '85,06,32,0A,80,07,47,00,00'
 // 0x82 Waypoint name: "WPT1" (6-bit encoded, little-endian)
 const waypointNameData = '82,05,27,D8,48,B7,06,F9'
 // 0x82 Waypoint name: "AB" (6-bit encoded, padded with zeros)


### PR DESCRIPTION
## Summary

Hey @tkurki @panaaj — quick follow-up to #278. Caught a bug in the 0x85 distance calculation.

The ZZZ nibble assembly was using `(Z_high << 8) | ZZ`, but `Z_high` is only a 4-bit nibble (high nibble of byte 4), so the correct formula is `(ZZ << 4) | Z_high`. This was producing wrong distance-to-waypoint values.

## What changed

- **`hooks/seatalk/0x85.js`**: Fixed ZZZ assembly from `(Z_high << 8) | ZZ` → `(ZZ << 4) | Z_high`
- **`test/seatalk.js`**: Updated test vectors to match the corrected byte order

## Testing

- All existing tests pass with corrected test vectors
- Verified against Thomas Knauf's SeaTalk Technical Reference