### PR TITLE
feat: add ETA support for AIS vessel

### DIFF
--- a/hooks/VDM.js
+++ b/hooks/VDM.js
@@ -117,6 +117,51 @@ const iceTable = {
   3: 'not available'
 }
 
+// AIS type 5 ETA has only month/day/hour/minute (no year). Returns an ISO string
+// using the current UTC year, rolling to next year when the date has already
+// passed. Returns undefined when any field is missing (non-type-5 messages) or
+// set to the AIS "not available" sentinel (month=0, day=0, hour=24, minute=60).
+function toDestinationEtaIso(etaMo, etaDay, etaHr, etaMin) {
+  const month = Number(etaMo)
+  const day = Number(etaDay)
+  const hour = Number(etaHr)
+  const minute = Number(etaMin)
+
+  if (
+    !Number.isInteger(month) ||
+    !Number.isInteger(day) ||
+    !Number.isInteger(hour) ||
+    !Number.isInteger(minute)
+  ) {
+    return undefined
+  }
+
+  if (
+    month < 1 ||
+    month > 12 ||
+    day < 1 ||
+    day > 31 ||
+    hour < 0 ||
+    hour > 23 ||
+    minute < 0 ||
+    minute > 59
+  ) {
+    return undefined
+  }
+
+  const now = new Date()
+  const year = now.getUTCFullYear()
+  const currentYearEta = new Date(
+    Date.UTC(year, month - 1, day, hour, minute, 0, 0)
+  )
+  if (currentYearEta.getTime() < now.getTime()) {
+    return new Date(
+      Date.UTC(year + 1, month - 1, day, hour, minute, 0, 0)
+    ).toISOString()
+  }
+  return currentYearEta.toISOString()
+}
+
 module.exports = function (input, session) {
   const { id, sentence, parts, tags } = input
   const data = new Decoder(sentence, session)
@@ -224,18 +269,17 @@ module.exports = function (input, session) {
     })
   }
 
-  if (typeof data.etaMo !== 'undefined' ||
-    typeof data.etaDay !== 'undefined' ||
-    typeof data.etaHr !== 'undefined' ||
-    typeof data.etaMin !== 'undefined'
-  ) {
-    const etaIso = toDestinationEtaIso(data.etaMo, data.etaDay, data.etaHr, data.etaMin);
-    if (etaIso) {
-      values.push({
-        path: 'navigation.destination.eta',
-        value: etaIso,
-      })
-    }
+  const etaIso = toDestinationEtaIso(
+    data.etaMo,
+    data.etaDay,
+    data.etaHr,
+    data.etaMin
+  )
+  if (etaIso) {
+    values.push({
+      path: 'navigation.destination.eta',
+      value: etaIso
+    })
   }
 
   if (data.callsign) {
@@ -438,32 +482,4 @@ module.exports = function (input, session) {
   }
 
   return delta
-}
-
-function toDestinationEtaIso(etaMo, etaDay, etaHr, etaMin) {
-  const month = Number(etaMo)
-  const day = Number(etaDay)
-  const hour = Number(etaHr)
-  const minute = Number(etaMin)
-
-  // AIS message type 5 uses 0/0/24/60 for "not available".
-  if (!Number.isInteger(month) || !Number.isInteger(day) || !Number.isInteger(hour) || !Number.isInteger(minute)) {
-    return undefined
-  }
-
-  if (month < 1 || month > 12 || day < 1 || day > 31 || hour < 0 || hour > 23 || minute < 0 || minute > 59) {
-    return undefined
-  }
-
-  const now = new Date()
-  const year = now.getUTCFullYear()
-
-  const currentYearEta = new Date(Date.UTC(year, month - 1, day, hour, minute, 0, 0))
-
-  // ETA has no year in AIS, so roll to next year when current-year date is in the past.
-  if (currentYearEta.getTime() < now.getTime()) {
-    return new Date(Date.UTC(year + 1, month - 1, day, hour, minute, 0, 0)).toISOString()
-  }
-
-  return currentYearEta.toISOString()
 }

--- a/hooks/VDM.js
+++ b/hooks/VDM.js
@@ -224,6 +224,20 @@ module.exports = function (input, session) {
     })
   }
 
+  if (typeof data.etaMo !== 'undefined' ||
+    typeof data.etaDay !== 'undefined' ||
+    typeof data.etaHr !== 'undefined' ||
+    typeof data.etaMin !== 'undefined'
+  ) {
+    const etaIso = toDestinationEtaIso(data.etaMo, data.etaDay, data.etaHr, data.etaMin);
+    if (etaIso) {
+      values.push({
+        path: 'navigation.destination.eta',
+        value: etaIso,
+      })
+    }
+  }
+
   if (data.callsign) {
     values.push({
       path: '',
@@ -424,4 +438,32 @@ module.exports = function (input, session) {
   }
 
   return delta
+}
+
+function toDestinationEtaIso(etaMo, etaDay, etaHr, etaMin) {
+  const month = Number(etaMo)
+  const day = Number(etaDay)
+  const hour = Number(etaHr)
+  const minute = Number(etaMin)
+
+  // AIS message type 5 uses 0/0/24/60 for "not available".
+  if (!Number.isInteger(month) || !Number.isInteger(day) || !Number.isInteger(hour) || !Number.isInteger(minute)) {
+    return undefined
+  }
+
+  if (month < 1 || month > 12 || day < 1 || day > 31 || hour < 0 || hour > 23 || minute < 0 || minute > 59) {
+    return undefined
+  }
+
+  const now = new Date()
+  const year = now.getUTCFullYear()
+
+  const currentYearEta = new Date(Date.UTC(year, month - 1, day, hour, minute, 0, 0))
+
+  // ETA has no year in AIS, so roll to next year when current-year date is in the past.
+  if (currentYearEta.getTime() < now.getTime()) {
+    return new Date(Date.UTC(year + 1, month - 1, day, hour, minute, 0, 0)).toISOString()
+  }
+
+  return currentYearEta.toISOString()
 }

--- a/test/VDM.js
+++ b/test/VDM.js
@@ -66,6 +66,53 @@ describe('VDM', function () {
     toFull(delta).should.be.validSignalK
   })
 
+  it('AIS type 5 with valid ETA produces navigation.destination.eta', () => {
+    // Type 5 encoded with etaMo=6, etaDay=15, etaHr=10, etaMin=30.
+    const delta = new Parser().parse(
+      '!AIVDM,1,1,,A,51mg=5D0Bm`L<4hh001@E=A<PU00000000000016<Pj:51WbN=kV@h00000000000000000,2*70\n'
+    )
+    const etaValue = delta.updates[0].values.find(
+      (pv) => pv.path === 'navigation.destination.eta'
+    ).value
+
+    // AIS ETA has no year: current year when still upcoming, else next year.
+    const now = new Date()
+    const currentYearEta = new Date(
+      Date.UTC(now.getUTCFullYear(), 5, 15, 10, 30, 0, 0)
+    )
+    const expectedYear =
+      currentYearEta.getTime() < now.getTime()
+        ? now.getUTCFullYear() + 1
+        : now.getUTCFullYear()
+    const expected = new Date(
+      Date.UTC(expectedYear, 5, 15, 10, 30, 0, 0)
+    ).toISOString()
+    etaValue.should.equal(expected)
+  })
+
+  it("AIS type 5 with 'not available' ETA sentinels omits ETA", () => {
+    // Type 5 encoded with etaMo=0, etaDay=0, etaHr=24, etaMin=60.
+    const delta = new Parser().parse(
+      '!AIVDM,1,1,,A,51mg=5D0Bm`L<4hh001@E=@p4000000000000016<Pj:500Ht=kSkQ@0000000000000000,2*2D\n'
+    )
+    should.not.exist(
+      delta.updates[0].values.find(
+        (pv) => pv.path === 'navigation.destination.eta'
+      )
+    )
+  })
+
+  it('AIS non-type-5 message does not include ETA', () => {
+    const delta = new Parser().parse(
+      '!AIVDM,1,1,,B,13aGra0P00PHid>NK9<2FOvHR624,0*3E\n'
+    )
+    should.not.exist(
+      delta.updates[0].values.find(
+        (pv) => pv.path === 'navigation.destination.eta'
+      )
+    )
+  })
+
   it('Single line converts ok', () => {
     const delta = new Parser().parse(
       '!AIVDM,1,1,,A,13aEOK?P00PD2wVMdLDRhgvL289?,0*26\n'


### PR DESCRIPTION
added ETA to AIS vessels path `navigation.destination.eta`.

As year and seconds are not provided via AIS, the year will be calculated and seconds are 0.

Tested with dummy data from my own NMEA0183 simulator.