### PR TITLE
chore(deps-dev): bump chai to 6, prettier to 3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,12 +11,6 @@ updates:
         update-types:
           - minor
           - patch
-    ignore:
-      # prettier 3 changes default formatting; needs a tree-wide reformat
-      # commit. Re-enable after that lands.
-      - dependency-name: prettier
-        update-types:
-          - version-update:semver-major
     labels:
       - dependencies
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,11 +12,6 @@ updates:
           - minor
           - patch
     ignore:
-      # chai-things (abandoned since 2014) only works with chai 4.x.
-      # Re-enable after migrating test suite off chai-things.
-      - dependency-name: chai
-        update-types:
-          - version-update:semver-major
       # prettier 3 changes default formatting; needs a tree-wide reformat
       # commit. Re-enable after that lands.
       - dependency-name: prettier

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ const parser = new Parser()
 try {
   // backslash starts an escape sequence in JavaScript code, so they need to be double in string literals
   const delta = parser.parse(
-    '\\s:airmar dst800,c:1438489697*13\\$SDDBT,17.0,f,5.1,M,2.8,F*3E'
+    '\\s:airmar dst800,c:1438489697*13\\$SDDBT,17.0,f,5.1,M,2.8,F*3E',
   )
   if (delta !== null) {
     console.log(`[delta] ${JSON.stringify(delta, null, 2)}`)

--- a/bench/moment.js
+++ b/bench/moment.js
@@ -50,16 +50,16 @@ function bench(label, sentence) {
   console.log(
     `${label.padEnd(4)}  min ${min.toFixed(0).padStart(6)} ns/op   ` +
       `median ${med.toFixed(0).padStart(6)} ns/op   ` +
-      `(${trials.map((t) => t.toFixed(0)).join(', ')})`
+      `(${trials.map((t) => t.toFixed(0)).join(', ')})`,
   )
   return { min, med, trials }
 }
 
 console.log(
-  `node ${process.version}  platform ${process.platform}/${process.arch}`
+  `node ${process.version}  platform ${process.platform}/${process.arch}`,
 )
 console.log(
-  `iterations per trial: ${ITERATIONS}   trials: ${TRIALS}   warmup: ${WARMUP}`
+  `iterations per trial: ${ITERATIONS}   trials: ${TRIALS}   warmup: ${WARMUP}`,
 )
 console.log('')
 const results = {}

--- a/bin/nmea0183-signalk
+++ b/bin/nmea0183-signalk
@@ -2,13 +2,13 @@
 
 const Parser = require('../lib/index.js')
 const parser = new Parser({
-  validateChecksum: false
+  validateChecksum: false,
 })
 
 process.stdin.resume()
 process.stdin.setEncoding('utf8')
 
-process.stdin.pipe(require('split')()).on('data', data => {
+process.stdin.pipe(require('split')()).on('data', (data) => {
   if (typeof data !== 'string') {
     return
   }
@@ -18,13 +18,12 @@ process.stdin.pipe(require('split')()).on('data', data => {
     if (delta !== null) {
       console.log(JSON.stringify(delta))
     }
-  }
-  catch(e) {
-      console.error('Encountered an error:', e.message)
+  } catch (e) {
+    console.error('Encountered an error:', e.message)
   }
 })
 
-process.stdin.on('error', err => {
+process.stdin.on('error', (err) => {
   console.error('Encountered an input error:', err.message)
   process.exit(1)
 })

--- a/hooks/APB.js
+++ b/hooks/APB.js
@@ -60,13 +60,13 @@ module.exports = function (input) {
   if (parts[0].trim().toUpperCase() === 'V') {
     // Don't parse this sentence as it's void.
     throw new Error(
-      "Not parsing sentence for it's void (LORAN-C blink/SNR warning)"
+      "Not parsing sentence for it's void (LORAN-C blink/SNR warning)",
     )
   }
 
   if (parts[1].trim().toUpperCase() === 'V') {
     throw new Error(
-      "Not parsing sentence for it's void (LORAN-C cycle warning)"
+      "Not parsing sentence for it's void (LORAN-C cycle warning)",
     )
   }
 
@@ -77,7 +77,7 @@ module.exports = function (input) {
     utils.transform(
       parts[2],
       parts[4].trim().toUpperCase() === 'N' ? 'nm' : 'km',
-      'm'
+      'm',
     )
 
   // WP arrival status

--- a/hooks/BWC.js
+++ b/hooks/BWC.js
@@ -77,7 +77,7 @@ module.exports = function BWCHook(input) {
     const distance = utils.transform(
       parts[9],
       upper(parts[10]) === 'N' ? 'nm' : 'km',
-      'm'
+      'm',
     )
     values.push({
       path: 'navigation.courseGreatCircle.nextPoint.distance',

--- a/hooks/BWR.js
+++ b/hooks/BWR.js
@@ -61,7 +61,7 @@ module.exports = function BWRHook(input) {
     distance = utils.transform(
       parts[9],
       upper(parts[10]) === 'N' ? 'nm' : 'km',
-      'm'
+      'm',
     )
     bearingToWaypoint[upper(parts[6]) === 'T' ? 'True' : 'Magnetic'] =
       utils.transform(parts[5], 'deg', 'rad')

--- a/hooks/GSV.js
+++ b/hooks/GSV.js
@@ -98,7 +98,7 @@ module.exports = function (input, session) {
 
   if (Number(parts[SENTENCE_NUMBER]) !== gsvData.nextSentenceNumber) {
     debug(
-      `Expected sentence number to be ${gsvData.nextSentenceNumber} but got ${parts}`
+      `Expected sentence number to be ${gsvData.nextSentenceNumber} but got ${parts}`,
     )
     delete session.gsvData
     return null
@@ -115,12 +115,12 @@ module.exports = function (input, session) {
         elevation: utils.transform(
           parts[thisSatDataStart + OFFSET_ELEVATION],
           'deg',
-          'rad'
+          'rad',
         ),
         azimuth: utils.transform(
           parts[thisSatDataStart + OFFSET_AZIMUTH],
           'deg',
-          'rad'
+          'rad',
         ),
         SNR: Number(parts[thisSatDataStart + OFFSET_SNR]),
       })

--- a/hooks/HDG.js
+++ b/hooks/HDG.js
@@ -56,7 +56,7 @@ module.exports = function (input) {
       value: utils.transform(
         utils.float(headingCompass) + effectiveDeviation,
         'deg',
-        'rad'
+        'rad',
       ),
     })
     if (!isEmpty(deviation)) {
@@ -72,7 +72,7 @@ module.exports = function (input) {
         value: utils.transform(
           utils.float(headingCompass) + effectiveDeviation + effectiveVariation,
           'deg',
-          'rad'
+          'rad',
         ),
       })
     }

--- a/hooks/RMC.js
+++ b/hooks/RMC.js
@@ -72,7 +72,7 @@ module.exports = function (input) {
       ? utils.transform(
           utils.magneticVariaton(parts[9], parts[10]),
           'deg',
-          'rad'
+          'rad',
         )
       : null
 

--- a/hooks/VDM.js
+++ b/hooks/VDM.js
@@ -367,7 +367,7 @@ module.exports = function (input, session) {
         {
           path: `environment.` + path + `Value`,
           value: data[propName],
-        }
+        },
       )
     }
   })
@@ -382,7 +382,7 @@ module.exports = function (input, session) {
       {
         path: 'environment.outside.horizontalVisibility.overRange',
         value: data.horvisibrange,
-      }
+      },
     )
   }
 

--- a/hooks/VWR.js
+++ b/hooks/VWR.js
@@ -69,7 +69,7 @@ module.exports = function (input) {
             value: utils.transform(
               utils.float(parts[0]) * rightPositive,
               'deg',
-              'rad'
+              'rad',
             ),
           },
           {

--- a/hooks/XTE.js
+++ b/hooks/XTE.js
@@ -41,13 +41,13 @@ module.exports = function XTEHook(input) {
   if (parts[0].trim().toUpperCase() === 'V') {
     // Don't parse this sentence as it's void.
     throw new Error(
-      "Not parsing sentence for it's void (LORAN-C blink/SNR warning)"
+      "Not parsing sentence for it's void (LORAN-C blink/SNR warning)",
     )
   }
 
   if (parts[1].trim().toUpperCase() === 'V') {
     throw new Error(
-      "Not parsing sentence for it's void (LORAN-C cycle warning)"
+      "Not parsing sentence for it's void (LORAN-C cycle warning)",
     )
   }
 
@@ -61,7 +61,7 @@ module.exports = function XTEHook(input) {
     utils.transform(
       parts[2],
       parts[4].trim().toUpperCase() === 'N' ? 'nm' : 'km',
-      'm'
+      'm',
     )
   const path = 'navigation.courseRhumbline.crossTrackError'
 

--- a/hooks/ZDA.js
+++ b/hooks/ZDA.js
@@ -74,7 +74,7 @@ module.exports = function (input) {
     const second = (parts[0] || '').substring(4, 6)
     const milliSecond = (parts[0].substring(4) % 1) * 1000
     const d = new Date(
-      Date.UTC(year, month, day, hour, minute, second, milliSecond)
+      Date.UTC(year, month, day, hour, minute, second, milliSecond),
     )
     const ts = d.toISOString()
     delta = {

--- a/hooks/seatalk/0x54.js
+++ b/hooks/seatalk/0x54.js
@@ -57,8 +57,8 @@ module.exports = function (input, session) {
         session['time'].hour,
         session['time'].minute,
         session['time'].second,
-        session['time'].milliSecond
-      )
+        session['time'].milliSecond,
+      ),
     )
     const ts = d.toISOString()
 

--- a/hooks/seatalk/0x56.js
+++ b/hooks/seatalk/0x56.js
@@ -46,8 +46,8 @@ module.exports = function (input, session) {
         session['time'].hour,
         session['time'].minute,
         session['time'].second,
-        session['time'].milliSecond
-      )
+        session['time'].milliSecond,
+      ),
     )
     const ts = d.toISOString()
 

--- a/hooks/seatalk/0x82.js
+++ b/hooks/seatalk/0x82.js
@@ -59,7 +59,7 @@ module.exports = function (input) {
   // '0' (0x30) represents empty character positions - strip leading/trailing zeros
   const waypointName = String.fromCharCode(c1, c2, c3, c4).replace(
     /^0+|0+$/g,
-    ''
+    '',
   )
 
   if (waypointName.length === 0) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,7 +28,7 @@ class Parser {
     opts = {
       emitPropertyValue: () => undefined,
       onPropertyValues: () => undefined,
-    }
+    },
   ) {
     this.options = typeof opts === 'object' && opts !== null ? opts : {}
     if (!Object.keys(this.options).includes('validateChecksum')) {
@@ -112,7 +112,7 @@ class Parser {
           tags,
           talker,
         },
-        this.session
+        this.session,
       )
       return transformSource(result, id, talker)
     } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "chai": "^6.2.2",
         "debug": "^4.0.1",
         "mocha": "^11.7.5",
-        "prettier": "^2.4.1"
+        "prettier": "^3.8.2"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
@@ -1768,16 +1768,16 @@
       "license": "ISC"
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.2.tgz",
+      "integrity": "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==",
       "dev": true,
       "license": "MIT",
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,7 @@
       "devDependencies": {
         "@signalk/github-create-release": "^1.2.0",
         "c8": "^11.0.0",
-        "chai": "^4.1.2",
-        "chai-things": "^0.2.0",
+        "chai": "^6.2.2",
         "debug": "^4.0.1",
         "mocha": "^11.7.5",
         "prettier": "^2.4.1"
@@ -621,16 +620,6 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
-    "node_modules/assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/atob-lite": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
@@ -737,30 +726,14 @@
       }
     },
     "node_modules/chai": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
-      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.3",
-        "deep-eql": "^4.1.3",
-        "get-func-name": "^2.0.2",
-        "loupe": "^2.3.6",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.1.0"
-      },
       "engines": {
-        "node": ">=4"
+        "node": ">=18"
       }
-    },
-    "node_modules/chai-things": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/chai-things/-/chai-things-0.2.0.tgz",
-      "integrity": "sha512-6ns0SU21xdRCoEXVKH3HGbwnsgfVMXQ+sU5V8PI9rfxaITos8lss1vUxbF1FAcJKjfqmmmLVlr/z3sLes00w+A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -790,19 +763,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/check-error": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
-      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-func-name": "^2.0.2"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/chokidar": {
@@ -984,19 +944,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/deep-eql": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
-      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "type-detect": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/deprecation": {
@@ -1213,16 +1160,6 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/get-func-name": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
-      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/get-stream": {
@@ -1528,16 +1465,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/loupe": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
-      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-func-name": "^2.0.1"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
@@ -1831,16 +1758,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/pathval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/picocolors": {
@@ -2275,16 +2192,6 @@
       "dependencies": {
         "moment": "^2.10.6",
         "validator": "^13.7.0"
-      }
-    },
-    "node_modules/type-detect": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
-      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
   "devDependencies": {
     "@signalk/github-create-release": "^1.2.0",
     "c8": "^11.0.0",
-    "chai": "^4.1.2",
-    "chai-things": "^0.2.0",
+    "chai": "^6.2.2",
     "debug": "^4.0.1",
     "mocha": "^11.7.5",
     "prettier": "^2.4.1"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "chai": "^6.2.2",
     "debug": "^4.0.1",
     "mocha": "^11.7.5",
-    "prettier": "^2.4.1"
+    "prettier": "^3.8.2"
   },
   "repository": {
     "type": "git",

--- a/test/APB.js
+++ b/test/APB.js
@@ -22,7 +22,6 @@ const should = chai.Should()
 const expect = chai.expect
 
 chai.Should()
-chai.use(require('chai-things'))
 
 describe('APB', (done) => {
   it('Converts OK using individual parser', () => {

--- a/test/APB.js
+++ b/test/APB.js
@@ -26,7 +26,7 @@ chai.Should()
 describe('APB', (done) => {
   it('Converts OK using individual parser', () => {
     const delta = new Parser().parse(
-      '$GPAPB,A,A,0.10,R,N,V,V,011,M,DEST,011,M,011,M*3C'
+      '$GPAPB,A,A,0.10,R,N,V,V,011,M,DEST,011,M,011,M*3C',
     )
     // console.log(JSON.stringify(delta, null, 2))
 
@@ -40,7 +40,7 @@ describe('APB', (done) => {
     delta.updates[0].values
       .find(
         (x) =>
-          x.path === 'navigation.courseRhumbline.bearingToDestinationMagnetic'
+          x.path === 'navigation.courseRhumbline.bearingToDestinationMagnetic',
       )
       .value.should.be.closeTo(0.19198621776321237, 0.000001)
     delta.updates[0].values
@@ -51,13 +51,13 @@ describe('APB', (done) => {
       .value.should.closeTo(0.19198621776321237, 0.0001)
     expect(
       delta.updates[0].values.find(
-        (x) => x.path === 'notifications.arrivalCircleEntered'
-      ).value
+        (x) => x.path === 'notifications.arrivalCircleEntered',
+      ).value,
     ).to.be.null
     expect(
       delta.updates[0].values.find(
-        (x) => x.path === 'notifications.perpendicularPassed'
-      ).value
+        (x) => x.path === 'notifications.perpendicularPassed',
+      ).value,
     ).to.be.null
   })
 

--- a/test/BOD.js
+++ b/test/BOD.js
@@ -31,28 +31,28 @@ describe('BOD', () => {
     delta.should.be.an('object')
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.courseRhumbline.bearingTrackTrue'
+      'navigation.courseRhumbline.bearingTrackTrue',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'value',
-      0.7853981635767779
+      0.7853981635767779,
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.courseRhumbline.bearingTrackMagnetic'
+      'navigation.courseRhumbline.bearingTrackMagnetic',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'value',
-      0.40142572805035315
+      0.40142572805035315,
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.courseRhumbline.nextPoint.ID'
+      'navigation.courseRhumbline.nextPoint.ID',
     )
     delta.updates[0].values.should.containItemWithProperty('value', 'DEST')
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.courseRhumbline.previousPoint.ID'
+      'navigation.courseRhumbline.previousPoint.ID',
     )
     delta.updates[0].values.should.containItemWithProperty('value', 'START')
   })

--- a/test/BOD.js
+++ b/test/BOD.js
@@ -21,7 +21,7 @@ const chai = require('chai')
 const should = chai.Should()
 
 chai.Should()
-chai.use(require('chai-things'))
+chai.use(require('./helpers/chai-has-item'))
 
 describe('BOD', () => {
   it('Converts OK using individual parser', () => {
@@ -29,38 +29,32 @@ describe('BOD', () => {
     // console.log(JSON.stringify(delta, null, 2))
 
     delta.should.be.an('object')
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.courseRhumbline.bearingTrackTrue'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'value',
       0.7853981635767779
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.courseRhumbline.bearingTrackMagnetic'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'value',
       0.40142572805035315
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.courseRhumbline.nextPoint.ID'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
-      'value',
-      'DEST'
-    )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty('value', 'DEST')
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.courseRhumbline.previousPoint.ID'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
-      'value',
-      'START'
-    )
+    delta.updates[0].values.should.containItemWithProperty('value', 'START')
   })
 
   it("Doesn't choke on an empty sentence", () => {

--- a/test/BWC.js
+++ b/test/BWC.js
@@ -21,7 +21,6 @@ const chai = require('chai')
 const should = chai.Should()
 
 chai.Should()
-chai.use(require('chai-things'))
 
 describe('BWC', () => {
   it('Converts OK using individual parser', () => {

--- a/test/BWC.js
+++ b/test/BWC.js
@@ -25,7 +25,7 @@ chai.Should()
 describe('BWC', () => {
   it('Converts OK using individual parser', () => {
     const delta = new Parser().parse(
-      '$GPBWC,225444,4917.24,N,12309.57,W,051.9,T,031.6,M,001.3,N,004*29'
+      '$GPBWC,225444,4917.24,N,12309.57,W,051.9,T,031.6,M,001.3,N,004*29',
     )
     // console.log(JSON.stringify(delta, null, 2))
 
@@ -57,7 +57,7 @@ describe('BWC', () => {
 
   it('Converts also without next position coordinates', () => {
     const delta = new Parser().parse(
-      '$IIBWC,200321,,,,,119.5,T,129.5,M,22.10,N,1*1E'
+      '$IIBWC,200321,,,,,119.5,T,129.5,M,22.10,N,1*1E',
     )
 
     delta.should.be.an('object')

--- a/test/BWR.js
+++ b/test/BWR.js
@@ -21,7 +21,6 @@ const chai = require('chai')
 const should = chai.Should()
 
 chai.Should()
-chai.use(require('chai-things'))
 
 describe('BWR', () => {
   it('Converts OK using individual parser', () => {

--- a/test/BWR.js
+++ b/test/BWR.js
@@ -25,7 +25,7 @@ chai.Should()
 describe('BWR', () => {
   it('Converts OK using individual parser', () => {
     const delta = new Parser().parse(
-      '$GPBWR,225444,4917.24,N,12309.57,W,051.9,T,031.6,M,001.3,N,004*38'
+      '$GPBWR,225444,4917.24,N,12309.57,W,051.9,T,031.6,M,001.3,N,004*38',
     )
     // console.log(JSON.stringify(delta, null, 2))
 

--- a/test/DBK.js
+++ b/test/DBK.js
@@ -27,7 +27,7 @@ describe('DBK', () => {
     const delta = new Parser().parse('$IIDBK,035.53,f,010.83,M,005.85,F*3C')
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'environment.depth.belowKeel'
+      'environment.depth.belowKeel',
     )
     delta.updates[0].values.should.containItemWithProperty('value', 10.83)
   })

--- a/test/DBK.js
+++ b/test/DBK.js
@@ -20,16 +20,16 @@ const Parser = require('../lib')
 const chai = require('chai')
 const should = chai.Should()
 
-chai.use(require('chai-things'))
+chai.use(require('./helpers/chai-has-item'))
 
 describe('DBK', () => {
   it('Converts OK using individual parser', () => {
     const delta = new Parser().parse('$IIDBK,035.53,f,010.83,M,005.85,F*3C')
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'environment.depth.belowKeel'
     )
-    delta.updates[0].values.should.contain.an.item.with.property('value', 10.83)
+    delta.updates[0].values.should.containItemWithProperty('value', 10.83)
   })
 
   it('Converts empty value to null', () => {

--- a/test/DBS.js
+++ b/test/DBS.js
@@ -20,16 +20,16 @@ const Parser = require('../lib')
 const chai = require('chai')
 const should = chai.Should()
 
-chai.use(require('chai-things'))
+chai.use(require('./helpers/chai-has-item'))
 
 describe('DBS', () => {
   it('Converts OK using individual parser', () => {
     const delta = new Parser().parse('$IIDBS,035.53,f,010.83,M,005.85,F*24')
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'environment.depth.belowSurface'
     )
-    delta.updates[0].values.should.contain.an.item.with.property('value', 10.83)
+    delta.updates[0].values.should.containItemWithProperty('value', 10.83)
   })
 
   it('Converts empty value to null', () => {

--- a/test/DBS.js
+++ b/test/DBS.js
@@ -27,7 +27,7 @@ describe('DBS', () => {
     const delta = new Parser().parse('$IIDBS,035.53,f,010.83,M,005.85,F*24')
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'environment.depth.belowSurface'
+      'environment.depth.belowSurface',
     )
     delta.updates[0].values.should.containItemWithProperty('value', 10.83)
   })
@@ -36,7 +36,7 @@ describe('DBS', () => {
     const delta = new Parser().parse('$IIDBS,,,,,,*55')
     delta.updates[0].values.length.should.equal(1)
     delta.updates[0].values[0].path.should.equal(
-      'environment.depth.belowSurface'
+      'environment.depth.belowSurface',
     )
     should.equal(delta.updates[0].values[0].value, null)
   })

--- a/test/DBT.js
+++ b/test/DBT.js
@@ -27,7 +27,7 @@ describe('DBT', () => {
     const delta = new Parser().parse('$IIDBT,035.53,f,010.83,M,005.85,F*23')
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'environment.depth.belowTransducer'
+      'environment.depth.belowTransducer',
     )
     delta.updates[0].values.should.containItemWithProperty('value', 10.83)
   })
@@ -38,7 +38,7 @@ describe('DBT', () => {
     delta.updates[0].values.length.should.equal(1)
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'environment.depth.belowTransducer'
+      'environment.depth.belowTransducer',
     )
     delta.updates[0].values.should.containItemWithProperty('value', 131.91744)
   })
@@ -47,7 +47,7 @@ describe('DBT', () => {
     const delta = new Parser().parse('$IIDBT,,,,,,*52')
     delta.updates[0].values.length.should.equal(1)
     delta.updates[0].values[0].path.should.equal(
-      'environment.depth.belowTransducer'
+      'environment.depth.belowTransducer',
     )
     should.equal(delta.updates[0].values[0].value, null)
   })

--- a/test/DBT.js
+++ b/test/DBT.js
@@ -20,30 +20,27 @@ const Parser = require('../lib')
 const chai = require('chai')
 const should = chai.Should()
 
-chai.use(require('chai-things'))
+chai.use(require('./helpers/chai-has-item'))
 
 describe('DBT', () => {
   it('Converts OK using individual parser', () => {
     const delta = new Parser().parse('$IIDBT,035.53,f,010.83,M,005.85,F*23')
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'environment.depth.belowTransducer'
     )
-    delta.updates[0].values.should.contain.an.item.with.property('value', 10.83)
+    delta.updates[0].values.should.containItemWithProperty('value', 10.83)
   })
 
   it('Converts with only feet in the sentence', () => {
     const delta = new Parser().parse('$IIDBT,432.8,f,,M,,F*1C')
     delta.updates.length.should.equal(1)
     delta.updates[0].values.length.should.equal(1)
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'environment.depth.belowTransducer'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
-      'value',
-      131.91744
-    )
+    delta.updates[0].values.should.containItemWithProperty('value', 131.91744)
   })
 
   it('Converts empty value to null', () => {

--- a/test/DPT.js
+++ b/test/DPT.js
@@ -27,7 +27,7 @@ describe('DPT', () => {
     const delta = new Parser().parse('$IIDPT,4.1,0.0*45')
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'environment.depth.belowTransducer'
+      'environment.depth.belowTransducer',
     )
     delta.updates[0].values.should.containItemWithProperty('value', 4.1)
   })
@@ -35,7 +35,7 @@ describe('DPT', () => {
   it('Converts OK with missing offset', () => {
     const delta = new Parser().parse('$IIDPT,4.1,*6B')
     delta.updates[0].values[0].path.should.equal(
-      'environment.depth.belowTransducer'
+      'environment.depth.belowTransducer',
     )
     delta.updates[0].values[0].value.should.equal(4.1)
   })
@@ -45,17 +45,17 @@ describe('DPT', () => {
 
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'environment.depth.belowTransducer'
+      'environment.depth.belowTransducer',
     )
     delta.updates[0].values.should.containItemWithProperty('value', 4.1)
 
     delta.updates[0].values[1].path.should.equal(
-      'environment.depth.surfaceToTransducer'
+      'environment.depth.surfaceToTransducer',
     )
     delta.updates[0].values[1].value.should.equal(1)
 
     delta.updates[0].values[2].path.should.equal(
-      'environment.depth.belowSurface'
+      'environment.depth.belowSurface',
     )
     delta.updates[0].values[2].value.should.equal(5.1)
   })
@@ -64,12 +64,12 @@ describe('DPT', () => {
     const delta = new Parser().parse('$IIDPT,4.1,-1.0*69')
 
     delta.updates[0].values[0].path.should.equal(
-      'environment.depth.belowTransducer'
+      'environment.depth.belowTransducer',
     )
     delta.updates[0].values[0].value.should.be.closeTo(4.1, 0.1)
 
     delta.updates[0].values[1].path.should.equal(
-      'environment.depth.transducerToKeel'
+      'environment.depth.transducerToKeel',
     )
     delta.updates[0].values[1].value.should.equal(1)
 
@@ -80,7 +80,7 @@ describe('DPT', () => {
   it('Converts empty depth to null', () => {
     const delta = new Parser().parse('$IIDPT,,,*6C')
     delta.updates[0].values[0].path.should.equal(
-      'environment.depth.belowTransducer'
+      'environment.depth.belowTransducer',
     )
     delta.updates[0].values.length.should.equal(1)
     should.equal(delta.updates[0].values[0].value, null)
@@ -90,11 +90,11 @@ describe('DPT', () => {
     const delta = new Parser().parse('$IIDPT,,0.1*6F')
     delta.updates[0].values.length.should.equal(2)
     delta.updates[0].values[0].path.should.equal(
-      'environment.depth.belowTransducer'
+      'environment.depth.belowTransducer',
     )
     should.equal(delta.updates[0].values[0].value, null)
     delta.updates[0].values[1].path.should.equal(
-      'environment.depth.surfaceToTransducer'
+      'environment.depth.surfaceToTransducer',
     )
     should.equal(delta.updates[0].values[1].value, 0.1)
   })

--- a/test/DPT.js
+++ b/test/DPT.js
@@ -20,16 +20,16 @@ const Parser = require('../lib')
 const chai = require('chai')
 const should = chai.Should()
 
-chai.use(require('chai-things'))
+chai.use(require('./helpers/chai-has-item'))
 
 describe('DPT', () => {
   it('Converts OK using individual parser', () => {
     const delta = new Parser().parse('$IIDPT,4.1,0.0*45')
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'environment.depth.belowTransducer'
     )
-    delta.updates[0].values.should.contain.an.item.with.property('value', 4.1)
+    delta.updates[0].values.should.containItemWithProperty('value', 4.1)
   })
 
   it('Converts OK with missing offset', () => {
@@ -43,11 +43,11 @@ describe('DPT', () => {
   it('Converts OK with positive offset', () => {
     const delta = new Parser().parse('$IIDPT,4.1,1.0*44')
 
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'environment.depth.belowTransducer'
     )
-    delta.updates[0].values.should.contain.an.item.with.property('value', 4.1)
+    delta.updates[0].values.should.containItemWithProperty('value', 4.1)
 
     delta.updates[0].values[1].path.should.equal(
       'environment.depth.surfaceToTransducer'

--- a/test/DSC.js
+++ b/test/DSC.js
@@ -1,7 +1,7 @@
 const Parser = require('../lib')
 const chai = require('chai')
 const should = chai.Should()
-chai.use(require('chai-things'))
+chai.use(require('./helpers/chai-has-item'))
 
 const nmeaLinePos = '$CDDSC,20,3381581370,00,21,26,1423108312,1902,,,B,E*7B'
 const nmeaLineDistress =
@@ -12,7 +12,7 @@ describe('DSC', () => {
   it('Position converts ok', () => {
     const delta = new Parser().parse(nmeaLinePos)
 
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.position'
     )
@@ -22,11 +22,11 @@ describe('DSC', () => {
   it('Distress converts ok', () => {
     const delta = new Parser().parse(nmeaLineDistress)
 
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.position'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'notifications.adrift'
     )

--- a/test/DSC.js
+++ b/test/DSC.js
@@ -14,7 +14,7 @@ describe('DSC', () => {
 
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.position'
+      'navigation.position',
     )
     delta.context.should.equal('vessels.urn:mrn:imo:mmsi:338158137')
   })
@@ -24,11 +24,11 @@ describe('DSC', () => {
 
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.position'
+      'navigation.position',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'notifications.adrift'
+      'notifications.adrift',
     )
     delta.context.should.equal('vessels.urn:mrn:imo:mmsi:338040079')
   })

--- a/test/GGA.js
+++ b/test/GGA.js
@@ -20,7 +20,7 @@ const Parser = require('../lib')
 const chai = require('chai')
 const should = chai.Should()
 
-chai.use(require('chai-things'))
+chai.use(require('./helpers/chai-has-item'))
 chai.use(require('@signalk/signalk-schema').chaiModule)
 
 const toFull = require('./toFull')
@@ -34,31 +34,31 @@ describe('GGA', () => {
     should.not.exist(delta.updates[0].source.label)
     delta.updates[0].source.talker.should.equal('GP')
     // Paths
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.position'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.gnss.methodQuality'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.gnss.satellites'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.gnss.antennaAltitude'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.gnss.horizontalDilution'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.gnss.differentialAge'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.gnss.differentialReference'
     )
@@ -103,31 +103,31 @@ describe('GGA', () => {
     should.not.exist(delta.updates[0].source.label)
     delta.updates[0].source.talker.should.equal('GP')
     // Paths
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.position'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.gnss.methodQuality'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.gnss.satellites'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.gnss.antennaAltitude'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.gnss.horizontalDilution'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.gnss.differentialAge'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.gnss.differentialReference'
     )

--- a/test/GGA.js
+++ b/test/GGA.js
@@ -28,7 +28,7 @@ const toFull = require('./toFull')
 describe('GGA', () => {
   it('Converts OK using individual parser', () => {
     const delta = new Parser().parse(
-      '$GPGGA,172814.0,3723.46587704,N,12202.26957864,W,2,6,1.2,18.893,M,-25.669,M,2.0,0031*4F'
+      '$GPGGA,172814.0,3723.46587704,N,12202.26957864,W,2,6,1.2,18.893,M,-25.669,M,2.0,0031*4F',
     )
 
     should.not.exist(delta.updates[0].source.label)
@@ -36,31 +36,31 @@ describe('GGA', () => {
     // Paths
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.position'
+      'navigation.position',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.gnss.methodQuality'
+      'navigation.gnss.methodQuality',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.gnss.satellites'
+      'navigation.gnss.satellites',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.gnss.antennaAltitude'
+      'navigation.gnss.antennaAltitude',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.gnss.horizontalDilution'
+      'navigation.gnss.horizontalDilution',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.gnss.differentialAge'
+      'navigation.gnss.differentialAge',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.gnss.differentialReference'
+      'navigation.gnss.differentialReference',
     )
     // Values
     delta.updates[0].values
@@ -97,7 +97,7 @@ describe('GGA', () => {
   it('Converts OK using individual parser with invalid lat/lng', () => {
     const delta = new Parser({ validateChecksum: false }).parse(
       // note this malformed lat value is pulled from a real validated malformed RMC example. see test/RMC.js
-      '$GPGGA,172814.0,1547\x0E70800,N,12202.26957864,W,2,6,1.2,18.893,M,-25.669,M,2.0,0031*4F'
+      '$GPGGA,172814.0,1547\x0E70800,N,12202.26957864,W,2,6,1.2,18.893,M,-25.669,M,2.0,0031*4F',
     )
 
     should.not.exist(delta.updates[0].source.label)
@@ -105,37 +105,37 @@ describe('GGA', () => {
     // Paths
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.position'
+      'navigation.position',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.gnss.methodQuality'
+      'navigation.gnss.methodQuality',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.gnss.satellites'
+      'navigation.gnss.satellites',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.gnss.antennaAltitude'
+      'navigation.gnss.antennaAltitude',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.gnss.horizontalDilution'
+      'navigation.gnss.horizontalDilution',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.gnss.differentialAge'
+      'navigation.gnss.differentialAge',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.gnss.differentialReference'
+      'navigation.gnss.differentialReference',
     )
     should.equal(
       delta.updates[0].values.find(
-        (value) => value.path === 'navigation.position'
+        (value) => value.path === 'navigation.position',
       ).value,
-      null
+      null,
     )
     delta.updates[0].values
       .find((value) => value.path === 'navigation.gnss.methodQuality')
@@ -170,7 +170,7 @@ describe('GGA', () => {
     // before/after window tolerates a test run straddling midnight UTC
     const before = new Date().toISOString().slice(0, 10)
     const delta = new Parser().parse(
-      '$GPGGA,172814.0,3723.46587704,N,12202.26957864,W,2,6,1.2,18.893,M,-25.669,M,2.0,0031*4F'
+      '$GPGGA,172814.0,3723.46587704,N,12202.26957864,W,2,6,1.2,18.893,M,-25.669,M,2.0,0031*4F',
     )
     const after = new Date().toISOString().slice(0, 10)
 

--- a/test/GLL.js
+++ b/test/GLL.js
@@ -19,7 +19,6 @@
 const Parser = require('../lib')
 const chai = require('chai')
 const should = chai.Should()
-chai.use(require('chai-things'))
 chai.use(require('@signalk/signalk-schema').chaiModule)
 
 describe('GLL', () => {

--- a/test/GLL.js
+++ b/test/GLL.js
@@ -24,17 +24,17 @@ chai.use(require('@signalk/signalk-schema').chaiModule)
 describe('GLL', () => {
   it('Converts OK using individual parser', () => {
     const delta = new Parser().parse(
-      '$GPGLL,5958.613,N,02325.928,E,121022,A,D*40'
+      '$GPGLL,5958.613,N,02325.928,E,121022,A,D*40',
     )
 
     delta.updates[0].values[0].path.should.equal('navigation.position')
     delta.updates[0].values[0].value.latitude.should.be.closeTo(
       59.9768833,
-      0.000005
+      0.000005,
     )
     delta.updates[0].values[0].value.longitude.should.be.closeTo(
       23.432133,
-      0.000005
+      0.000005,
     )
     // delta.should.be.validSignalKDelta
   })
@@ -42,7 +42,7 @@ describe('GLL', () => {
   it('Converts OK using individual parser, invalid lat/lng', () => {
     const delta = new Parser({ validateChecksum: false }).parse(
       // note this malformed lat value is pulled from a real validated malformed RMC example. see test/RMC.js
-      '$GPGLL,1547\x0E70800,N,02325.928,E,121022,A,D*40'
+      '$GPGLL,1547\x0E70800,N,02325.928,E,121022,A,D*40',
     )
 
     delta.updates[0].values[0].path.should.equal('navigation.position')
@@ -58,7 +58,7 @@ describe('GLL', () => {
     // before/after window tolerates a test run straddling midnight UTC
     const before = new Date().toISOString().slice(0, 10)
     const delta = new Parser().parse(
-      '$GPGLL,5958.613,N,02325.928,E,121022,A,D*40'
+      '$GPGLL,5958.613,N,02325.928,E,121022,A,D*40',
     )
     const after = new Date().toISOString().slice(0, 10)
 

--- a/test/GNS.js
+++ b/test/GNS.js
@@ -20,7 +20,7 @@ const Parser = require('../lib')
 const chai = require('chai')
 const should = chai.Should()
 
-chai.use(require('chai-things'))
+chai.use(require('./helpers/chai-has-item'))
 chai.use(require('@signalk/signalk-schema').chaiModule)
 
 const toFull = require('./toFull')
@@ -32,39 +32,39 @@ describe('GNS', () => {
     )
 
     // Paths
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.position'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.gnss.methodQuality'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.gnss.satellites'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.gnss.antennaAltitude'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.gnss.horizontalDilution'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.gnss.geoidalSeparation'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.gnss.differentialAge'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.gnss.differentialReference'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.gnss.status'
     )
@@ -95,39 +95,39 @@ describe('GNS', () => {
       '$GPGNS,111648.00,1547\x0E70800,S,04422.1450,W,ANN,12,0.8,8.5,-22.3,,,S*5D'
     )
     // Paths
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.position'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.gnss.methodQuality'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.gnss.satellites'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.gnss.antennaAltitude'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.gnss.horizontalDilution'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.gnss.geoidalSeparation'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.gnss.differentialAge'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.gnss.differentialReference'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.gnss.status'
     )

--- a/test/GNS.js
+++ b/test/GNS.js
@@ -28,45 +28,45 @@ const toFull = require('./toFull')
 describe('GNS', () => {
   it('Converts OK using individual parser', () => {
     const delta = new Parser().parse(
-      '$GPGNS,111648.00,0235.0379,S,04422.1450,W,ANN,12,0.8,8.5,-22.3,,,S*5D'
+      '$GPGNS,111648.00,0235.0379,S,04422.1450,W,ANN,12,0.8,8.5,-22.3,,,S*5D',
     )
 
     // Paths
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.position'
+      'navigation.position',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.gnss.methodQuality'
+      'navigation.gnss.methodQuality',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.gnss.satellites'
+      'navigation.gnss.satellites',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.gnss.antennaAltitude'
+      'navigation.gnss.antennaAltitude',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.gnss.horizontalDilution'
+      'navigation.gnss.horizontalDilution',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.gnss.geoidalSeparation'
+      'navigation.gnss.geoidalSeparation',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.gnss.differentialAge'
+      'navigation.gnss.differentialAge',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.gnss.differentialReference'
+      'navigation.gnss.differentialReference',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.gnss.status'
+      'navigation.gnss.status',
     )
 
     // Values
@@ -92,44 +92,44 @@ describe('GNS', () => {
   it('Converts OK using individual parser', () => {
     const delta = new Parser({ validateChecksum: false }).parse(
       // note this malformed lat value is pulled from a real validated malformed RMC example. see test/RMC.js
-      '$GPGNS,111648.00,1547\x0E70800,S,04422.1450,W,ANN,12,0.8,8.5,-22.3,,,S*5D'
+      '$GPGNS,111648.00,1547\x0E70800,S,04422.1450,W,ANN,12,0.8,8.5,-22.3,,,S*5D',
     )
     // Paths
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.position'
+      'navigation.position',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.gnss.methodQuality'
+      'navigation.gnss.methodQuality',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.gnss.satellites'
+      'navigation.gnss.satellites',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.gnss.antennaAltitude'
+      'navigation.gnss.antennaAltitude',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.gnss.horizontalDilution'
+      'navigation.gnss.horizontalDilution',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.gnss.geoidalSeparation'
+      'navigation.gnss.geoidalSeparation',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.gnss.differentialAge'
+      'navigation.gnss.differentialAge',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.gnss.differentialReference'
+      'navigation.gnss.differentialReference',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.gnss.status'
+      'navigation.gnss.status',
     )
 
     // Values
@@ -157,7 +157,7 @@ describe('GNS', () => {
     // before/after window tolerates a test run straddling midnight UTC
     const before = new Date().toISOString().slice(0, 10)
     const delta = new Parser().parse(
-      '$GPGNS,111648.00,0235.0379,S,04422.1450,W,ANN,12,0.8,8.5,-22.3,,,S*5D'
+      '$GPGNS,111648.00,0235.0379,S,04422.1450,W,ANN,12,0.8,8.5,-22.3,,,S*5D',
     )
     const after = new Date().toISOString().slice(0, 10)
 

--- a/test/HDG.js
+++ b/test/HDG.js
@@ -25,15 +25,15 @@ describe('HDG', () => {
     const delta = new Parser().parse('$SDHDG,181.9,,,0.6,E*32')
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.headingMagnetic'
+      'navigation.headingMagnetic',
     )
     delta.updates[0].values[0].value.should.be.closeTo(
       (181.9 / 180) * Math.PI,
-      0.005
+      0.005,
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.magneticVariation'
+      'navigation.magneticVariation',
     )
     delta.updates[0].values
       .find((pv) => pv.path === 'navigation.magneticVariation')
@@ -45,11 +45,11 @@ describe('HDG', () => {
 
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.headingMagnetic'
+      'navigation.headingMagnetic',
     )
     delta.updates[0].values[0].value.should.be.closeTo(
       (51.5 / 180) * Math.PI,
-      0.005
+      0.005,
     )
   })
 

--- a/test/HDG.js
+++ b/test/HDG.js
@@ -18,12 +18,12 @@ const Parser = require('../lib')
 const chai = require('chai')
 const should = chai.Should()
 
-chai.use(require('chai-things'))
+chai.use(require('./helpers/chai-has-item'))
 
 describe('HDG', () => {
   it('Converts OK using individual parser', () => {
     const delta = new Parser().parse('$SDHDG,181.9,,,0.6,E*32')
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.headingMagnetic'
     )
@@ -31,7 +31,7 @@ describe('HDG', () => {
       (181.9 / 180) * Math.PI,
       0.005
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.magneticVariation'
     )
@@ -43,7 +43,7 @@ describe('HDG', () => {
   it('Sentence with just heading works', () => {
     const delta = new Parser().parse('$HCHDG,51.5,,,,*73')
 
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.headingMagnetic'
     )

--- a/test/HDM.js
+++ b/test/HDM.js
@@ -20,13 +20,13 @@ const Parser = require('../lib')
 const chai = require('chai')
 const should = chai.Should()
 
-chai.use(require('chai-things'))
+chai.use(require('./helpers/chai-has-item'))
 
 describe('HDM', () => {
   it('Converts OK using individual parser', () => {
     const delta = new Parser().parse('$04HDM,186.5,M*2C')
 
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.headingMagnetic'
     )

--- a/test/HDM.js
+++ b/test/HDM.js
@@ -28,7 +28,7 @@ describe('HDM', () => {
 
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.headingMagnetic'
+      'navigation.headingMagnetic',
     )
     delta.updates[0].values[0].value.should.be.closeTo(3.26, 0.005)
   })

--- a/test/HDT.js
+++ b/test/HDT.js
@@ -27,7 +27,7 @@ describe('HDT', () => {
     const delta = new Parser().parse('$GPHDT,123.456,T*32')
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.headingTrue'
+      'navigation.headingTrue',
     )
     delta.updates[0].values[0].value.should.be.closeTo(2.155, 0.005)
   })

--- a/test/HDT.js
+++ b/test/HDT.js
@@ -20,12 +20,12 @@ const Parser = require('../lib')
 const chai = require('chai')
 const should = chai.Should()
 
-chai.use(require('chai-things'))
+chai.use(require('./helpers/chai-has-item'))
 
 describe('HDT', () => {
   it('Converts OK using individual parser', () => {
     const delta = new Parser().parse('$GPHDT,123.456,T*32')
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.headingTrue'
     )

--- a/test/HSC.js
+++ b/test/HSC.js
@@ -21,7 +21,7 @@ const chai = require('chai')
 const should = chai.Should()
 
 chai.Should()
-chai.use(require('chai-things'))
+chai.use(require('./helpers/chai-has-item'))
 
 describe('HSC', () => {
   it('Converts OK using individual parser', () => {
@@ -29,19 +29,19 @@ describe('HSC', () => {
     // console.log(JSON.stringify(delta, null, 2))
 
     delta.should.be.an('object')
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'steering.autopilot.target.headingTrue'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'value',
       0.7002260960600073
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'steering.autopilot.target.headingMagnetic'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'value',
       0.6825982706108397
     )

--- a/test/HSC.js
+++ b/test/HSC.js
@@ -31,19 +31,19 @@ describe('HSC', () => {
     delta.should.be.an('object')
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'steering.autopilot.target.headingTrue'
+      'steering.autopilot.target.headingTrue',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'value',
-      0.7002260960600073
+      0.7002260960600073,
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'steering.autopilot.target.headingMagnetic'
+      'steering.autopilot.target.headingMagnetic',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'value',
-      0.6825982706108397
+      0.6825982706108397,
     )
   })
 

--- a/test/MDA.js
+++ b/test/MDA.js
@@ -41,7 +41,7 @@ const Parser = require('../lib')
 const chai = require('chai')
 
 chai.Should()
-chai.use(require('chai-things'))
+chai.use(require('./helpers/chai-has-item'))
 
 describe('MDA', () => {
   it('check parsing with barometric pressure and wind speed in knots', () => {
@@ -49,39 +49,39 @@ describe('MDA', () => {
       '$WIMDA,,I,+0.985,B,+03.1,C,+5.6,C,40.0,3.0,+3.4,C,90.0,T,85.0,M,10.0,N,,M*1A'
     )
 
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'environment.outside.pressure'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'environment.outside.temperature'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'environment.water.temperature'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'environment.outside.humidity'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'environment.outside.humidityAbsolute'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'environment.outside.dewPointTemperature'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'environment.wind.directionTrue'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'environment.wind.directionMagnetic'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'environment.wind.speedOverGround'
     )
@@ -120,39 +120,39 @@ describe('MDA', () => {
       '$WIMDA,29.92,I,,B,+03.1,C,+5.6,C,40.0,3.0,+3.4,C,90.0,T,85.0,M,,N,5.0,M*01'
     )
 
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'environment.outside.pressure'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'environment.outside.temperature'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'environment.water.temperature'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'environment.outside.humidity'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'environment.outside.humidityAbsolute'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'environment.outside.dewPointTemperature'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'environment.wind.directionTrue'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'environment.wind.directionMagnetic'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'environment.wind.speedOverGround'
     )

--- a/test/MDA.js
+++ b/test/MDA.js
@@ -46,44 +46,44 @@ chai.use(require('./helpers/chai-has-item'))
 describe('MDA', () => {
   it('check parsing with barometric pressure and wind speed in knots', () => {
     const delta = new Parser().parse(
-      '$WIMDA,,I,+0.985,B,+03.1,C,+5.6,C,40.0,3.0,+3.4,C,90.0,T,85.0,M,10.0,N,,M*1A'
+      '$WIMDA,,I,+0.985,B,+03.1,C,+5.6,C,40.0,3.0,+3.4,C,90.0,T,85.0,M,10.0,N,,M*1A',
     )
 
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'environment.outside.pressure'
+      'environment.outside.pressure',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'environment.outside.temperature'
+      'environment.outside.temperature',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'environment.water.temperature'
+      'environment.water.temperature',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'environment.outside.humidity'
+      'environment.outside.humidity',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'environment.outside.humidityAbsolute'
+      'environment.outside.humidityAbsolute',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'environment.outside.dewPointTemperature'
+      'environment.outside.dewPointTemperature',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'environment.wind.directionTrue'
+      'environment.wind.directionTrue',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'environment.wind.directionMagnetic'
+      'environment.wind.directionMagnetic',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'environment.wind.speedOverGround'
+      'environment.wind.speedOverGround',
     )
 
     delta.updates[0].values
@@ -117,44 +117,44 @@ describe('MDA', () => {
 
   it('check parsing with inHg pressure and wind speed in m/s', () => {
     const delta = new Parser().parse(
-      '$WIMDA,29.92,I,,B,+03.1,C,+5.6,C,40.0,3.0,+3.4,C,90.0,T,85.0,M,,N,5.0,M*01'
+      '$WIMDA,29.92,I,,B,+03.1,C,+5.6,C,40.0,3.0,+3.4,C,90.0,T,85.0,M,,N,5.0,M*01',
     )
 
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'environment.outside.pressure'
+      'environment.outside.pressure',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'environment.outside.temperature'
+      'environment.outside.temperature',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'environment.water.temperature'
+      'environment.water.temperature',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'environment.outside.humidity'
+      'environment.outside.humidity',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'environment.outside.humidityAbsolute'
+      'environment.outside.humidityAbsolute',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'environment.outside.dewPointTemperature'
+      'environment.outside.dewPointTemperature',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'environment.wind.directionTrue'
+      'environment.wind.directionTrue',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'environment.wind.directionMagnetic'
+      'environment.wind.directionMagnetic',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'environment.wind.speedOverGround'
+      'environment.wind.speedOverGround',
     )
 
     delta.updates[0].values

--- a/test/MTA.js
+++ b/test/MTA.js
@@ -25,7 +25,7 @@ describe('MTA', () => {
     const delta = new Parser().parse('$IIMTA,26.,C*31')
 
     delta.updates[0].values[0].path.should.equal(
-      'environment.outside.temperature'
+      'environment.outside.temperature',
     )
     delta.updates[0].values[0].value.should.be.closeTo(299.15, 0.005)
   })
@@ -40,7 +40,7 @@ describe('MTA', () => {
     const delta = new Parser().parse('$RAMTA,,C*08')
     delta.updates[0].values.length.should.equal(1)
     delta.updates[0].values[0].path.should.equal(
-      'environment.outside.temperature'
+      'environment.outside.temperature',
     )
     chai.expect(delta.updates[0].values[0].value).to.be.null
   })

--- a/test/MTA.js
+++ b/test/MTA.js
@@ -20,8 +20,6 @@ const Parser = require('../lib')
 const chai = require('chai')
 const should = chai.Should()
 
-chai.use(require('chai-things'))
-
 describe('MTA', () => {
   it('Converts OK using individual parser', () => {
     const delta = new Parser().parse('$IIMTA,26.,C*31')

--- a/test/MTW.js
+++ b/test/MTW.js
@@ -20,13 +20,13 @@ const Parser = require('../lib')
 const chai = require('chai')
 
 chai.Should()
-chai.use(require('chai-things'))
+chai.use(require('./helpers/chai-has-item'))
 
 describe('MTW', () => {
   it('Converts OK using individual parser', () => {
     const delta = new Parser().parse('$YXMTW,15.2,C*14')
 
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'environment.water.temperature'
     )

--- a/test/MTW.js
+++ b/test/MTW.js
@@ -28,7 +28,7 @@ describe('MTW', () => {
 
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'environment.water.temperature'
+      'environment.water.temperature',
     )
     delta.updates[0].values[0].value.should.be.closeTo(288.35, 0.005)
   })
@@ -37,7 +37,7 @@ describe('MTW', () => {
     const delta = new Parser().parse('$RAMTW,,C*1E')
     delta.updates[0].values.length.should.equal(1)
     delta.updates[0].values[0].path.should.equal(
-      'environment.water.temperature'
+      'environment.water.temperature',
     )
     chai.expect(delta.updates[0].values[0].value).to.be.null
   })

--- a/test/MWD.js
+++ b/test/MWD.js
@@ -20,8 +20,6 @@ const Parser = require('../lib')
 const chai = require('chai')
 const should = chai.Should()
 
-chai.use(require('chai-things'))
-
 describe('MWD', () => {
   it('speed & direction data (#1)', () => {
     const delta = new Parser().parse('$IIMWD,,,046.,M,10.1,N,05.2,M*0B')

--- a/test/MWD.js
+++ b/test/MWD.js
@@ -25,7 +25,7 @@ describe('MWD', () => {
     const delta = new Parser().parse('$IIMWD,,,046.,M,10.1,N,05.2,M*0B')
 
     delta.updates[0].values[0].path.should.equal(
-      'environment.wind.directionMagnetic'
+      'environment.wind.directionMagnetic',
     )
     delta.updates[0].values[0].value.should.be.closeTo(0.802851, 0.00005)
     delta.updates[0].values[1].path.should.equal('environment.wind.speedTrue')
@@ -36,11 +36,11 @@ describe('MWD', () => {
     const delta = new Parser().parse('$IIMWD,046.,T,046.,M,10.1,N,,*17')
 
     delta.updates[0].values[0].path.should.equal(
-      'environment.wind.directionTrue'
+      'environment.wind.directionTrue',
     )
     delta.updates[0].values[0].value.should.be.closeTo(0.802851, 0.00005)
     delta.updates[0].values[1].path.should.equal(
-      'environment.wind.directionMagnetic'
+      'environment.wind.directionMagnetic',
     )
     delta.updates[0].values[1].value.should.be.closeTo(0.802851, 0.00005)
     delta.updates[0].values[2].path.should.equal('environment.wind.speedTrue')
@@ -51,7 +51,7 @@ describe('MWD', () => {
     const delta = new Parser().parse('$IIMWD,046.,T,,,,,5.2,M*72')
 
     delta.updates[0].values[0].path.should.equal(
-      'environment.wind.directionTrue'
+      'environment.wind.directionTrue',
     )
     delta.updates[0].values[0].value.should.be.closeTo(0.802851, 0.00005)
     delta.updates[0].values[1].path.should.equal('environment.wind.speedTrue')
@@ -98,7 +98,7 @@ describe('MWD', () => {
     const delta = new Parser().parse('$IIMWD,046.,T,0.,m,10.1,N,5.2,M*51')
 
     delta.updates[0].values[0].path.should.equal(
-      'environment.wind.directionTrue'
+      'environment.wind.directionTrue',
     )
     delta.updates[0].values[0].value.should.be.closeTo(0.802851, 0.00005)
     delta.updates[0].values[1].path.should.equal('environment.wind.speedTrue')
@@ -109,7 +109,7 @@ describe('MWD', () => {
     const delta = new Parser().parse('$IIMWD,,,046.,M,10.1,N,0.0,m*1C')
 
     delta.updates[0].values[0].path.should.equal(
-      'environment.wind.directionMagnetic'
+      'environment.wind.directionMagnetic',
     )
     delta.updates[0].values[0].value.should.be.closeTo(0.802851, 0.00005)
     delta.updates[0].values[1].path.should.equal('environment.wind.speedTrue')

--- a/test/MWV.js
+++ b/test/MWV.js
@@ -12,11 +12,11 @@ describe('MWV', () => {
 
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'environment.wind.angleTrueWater'
+      'environment.wind.angleTrueWater',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'value',
-      1.2915436467707015
+      1.2915436467707015,
     )
   })
 
@@ -25,11 +25,11 @@ describe('MWV', () => {
 
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'environment.wind.angleApparent'
+      'environment.wind.angleApparent',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'value',
-      -0.41887902057428156
+      -0.41887902057428156,
     )
   })
 

--- a/test/MWV.js
+++ b/test/MWV.js
@@ -4,17 +4,17 @@ const Parser = require('../lib')
 const chai = require('chai')
 const should = chai.Should()
 
-chai.use(require('chai-things'))
+chai.use(require('./helpers/chai-has-item'))
 
 describe('MWV', () => {
   it('True wind converts ok', () => {
     const delta = new Parser().parse('$IIMWV,074,T,05.85,N,A*2E')
 
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'environment.wind.angleTrueWater'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'value',
       1.2915436467707015
     )
@@ -23,11 +23,11 @@ describe('MWV', () => {
   it('Apparent wind converts ok', () => {
     const delta = new Parser().parse('$IIMWV,336,R,13.41,N,A*22')
 
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'environment.wind.angleApparent'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'value',
       -0.41887902057428156
     )

--- a/test/PBVE.js
+++ b/test/PBVE.js
@@ -23,11 +23,11 @@ const toFull = require('./toFull')
 describe('PBVE', () => {
   it('Converts engine oil pressure using individual parser', () => {
     const delta = new Parser().parse(
-      '$PBVE,DGOIADNNACAEACAAABBLAAEBAACMCFAAEPAIKI*37'
+      '$PBVE,DGOIADNNACAEACAAABBLAAEBAACMCFAAEPAIKI*37',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'propulsion.0.oilPressure'
+      'propulsion.0.oilPressure',
     )
     delta.updates[0].values[0].value.should.equal(255106.009)
     delta.updates[0].values[0].meta.should.deep.equal({
@@ -59,11 +59,11 @@ describe('PBVE', () => {
   })
   it('Converts engine coolant temperature using individual parser', () => {
     const delta = new Parser().parse(
-      '$PBVE,EDOIADOKACABABAAAACAPPCMABCGADABDOAEGL*20'
+      '$PBVE,EDOIADOKACABABAAAACAPPCMABCGADABDOAEGL*20',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'propulsion.0.coolantTemperature'
+      'propulsion.0.coolantTemperature',
     )
     delta.updates[0].values[0].value.should.equal(399.26111111111106)
     delta.updates[0].values[0].meta.should.deep.equal({
@@ -103,8 +103,8 @@ describe('PBVE', () => {
     // )
     should.not.exist(
       new Parser().parse(
-        '$PBVE,AQHKAAAACIAAAAABAAGEDOBCAAAAFLABCKAADIAADIAAAAAANDEN*3F'
-      )
+        '$PBVE,AQHKAAAACIAAAAABAAGEDOBCAAAAFLABCKAADIAADIAAAAAANDEN*3F',
+      ),
     )
   })
 })

--- a/test/PBVE.js
+++ b/test/PBVE.js
@@ -15,7 +15,9 @@
  */
 
 const Parser = require('../lib')
-const should = require('chai').Should()
+const chai = require('chai')
+const should = chai.Should()
+chai.use(require('./helpers/chai-has-item'))
 const toFull = require('./toFull')
 
 describe('PBVE', () => {
@@ -23,7 +25,7 @@ describe('PBVE', () => {
     const delta = new Parser().parse(
       '$PBVE,DGOIADNNACAEACAAABBLAAEBAACMCFAAEPAIKI*37'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'propulsion.0.oilPressure'
     )
@@ -59,7 +61,7 @@ describe('PBVE', () => {
     const delta = new Parser().parse(
       '$PBVE,EDOIADOKACABABAAAACAPPCMABCGADABDOAEGL*20'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'propulsion.0.coolantTemperature'
     )

--- a/test/PNKEP.js
+++ b/test/PNKEP.js
@@ -27,11 +27,11 @@ describe('PNKEP', () => {
     const delta = new Parser().parse('$PNKEP,01,8.3,N,15.5,K*52')
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'performance.targetSpeed'
+      'performance.targetSpeed',
     )
     delta.updates[0].values[0].value.should.be.closeTo(
       4.269889970594349,
-      0.0005
+      0.0005,
     )
     toFull(delta).should.be.validSignalK
   })
@@ -41,7 +41,7 @@ describe('PNKEP', () => {
 
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'performance.tackMagnetic'
+      'performance.tackMagnetic',
     )
     delta.updates[0].values[0].value.should.be.closeTo(6.0109139439, 0.00005)
     toFull(delta).should.be.validSignalK
@@ -52,7 +52,7 @@ describe('PNKEP', () => {
 
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'performance.targetAngle'
+      'performance.targetAngle',
     )
     delta.updates[0].values[0].value.should.be.closeTo(2.652900463, 0.00005)
     toFull(delta).should.be.validSignalK

--- a/test/PNKEP.js
+++ b/test/PNKEP.js
@@ -20,12 +20,12 @@ const chai = require('chai')
 const should = chai.Should()
 
 chai.use(require('@signalk/signalk-schema').chaiModule)
-chai.use(require('chai-things'))
+chai.use(require('./helpers/chai-has-item'))
 
 describe('PNKEP', () => {
   it('Polarspeed data ', () => {
     const delta = new Parser().parse('$PNKEP,01,8.3,N,15.5,K*52')
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'performance.targetSpeed'
     )
@@ -39,7 +39,7 @@ describe('PNKEP', () => {
   it('Course on next track data', () => {
     const delta = new Parser().parse('$PNKEP,02,344.4*6B')
 
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'performance.tackMagnetic'
     )
@@ -50,7 +50,7 @@ describe('PNKEP', () => {
   it('Direction data', () => {
     const delta = new Parser().parse('$PNKEP,03,152.0,55.2,67.1*69')
 
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'performance.targetAngle'
     )

--- a/test/RMB.js
+++ b/test/RMB.js
@@ -18,7 +18,7 @@ const Parser = require('../lib')
 const chai = require('chai')
 const should = chai.Should()
 
-chai.use(require('chai-things'))
+chai.use(require('./helpers/chai-has-item'))
 chai.use(require('@signalk/signalk-schema').chaiModule)
 
 describe('RMB', () => {
@@ -28,23 +28,23 @@ describe('RMB', () => {
     )
     should.equal(delta.updates[0].timestamp, undefined)
 
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.courseRhumbline.nextPoint.position'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.courseRhumbline.nextPoint.distance'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.courseRhumbline.nextPoint.bearingTrue'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.courseRhumbline.nextPoint.velocityMadeGood'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.courseRhumbline.crossTrackError'
     )
@@ -75,11 +75,11 @@ describe('RMB', () => {
 
   it("Doesn't choke on empty sentences", () => {
     const delta = new Parser().parse('$ECRMB,,,,,,,,,,,,,*77')
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.courseRhumbline.nextPoint.position'
     )
-    delta.updates[0].values.should.contain.an.item({
+    delta.updates[0].values.should.containItemMatching({
       path: 'navigation.courseRhumbline.nextPoint.position',
       value: null,
     })

--- a/test/RMB.js
+++ b/test/RMB.js
@@ -24,34 +24,34 @@ chai.use(require('@signalk/signalk-schema').chaiModule)
 describe('RMB', () => {
   it('Converts OK using individual parser', () => {
     const delta = new Parser().parse(
-      '$ECRMB,A,0.000,L,001,002,4653.550,N,07115.984,W,2.505,334.205,0.000,V*04'
+      '$ECRMB,A,0.000,L,001,002,4653.550,N,07115.984,W,2.505,334.205,0.000,V*04',
     )
     should.equal(delta.updates[0].timestamp, undefined)
 
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.courseRhumbline.nextPoint.position'
+      'navigation.courseRhumbline.nextPoint.position',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.courseRhumbline.nextPoint.distance'
+      'navigation.courseRhumbline.nextPoint.distance',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.courseRhumbline.nextPoint.bearingTrue'
+      'navigation.courseRhumbline.nextPoint.bearingTrue',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.courseRhumbline.nextPoint.velocityMadeGood'
+      'navigation.courseRhumbline.nextPoint.velocityMadeGood',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.courseRhumbline.crossTrackError'
+      'navigation.courseRhumbline.crossTrackError',
     )
     delta.updates[0].values[0].value.latitude.should.be.closeTo(46.8925, 0.005)
     delta.updates[0].values[0].value.longitude.should.be.closeTo(
       -71.2664,
-      0.005
+      0.005,
     )
     delta.updates[0].values[1].value.should.be.closeTo(5.832, 0.005)
     delta.updates[0].values[2].value.should.be.closeTo(0, 0.005)
@@ -61,14 +61,14 @@ describe('RMB', () => {
 
   it('crossTrackError should be negative to steer right', () => {
     const delta = new Parser().parse(
-      '$ECRMB,A,0.432,R,001,002,4653.550,N,07115.984,W,2.505,334.205,0.000,V*1F'
+      '$ECRMB,A,0.432,R,001,002,4653.550,N,07115.984,W,2.505,334.205,0.000,V*1F',
     )
     delta.updates[0].values[4].value.should.be.closeTo(-800.064, 0.005)
   })
 
   it('crossTrackError should be positive to steer left', () => {
     const delta = new Parser().parse(
-      '$ECRMB,A,0.432,L,001,002,4653.550,N,07115.984,W,2.505,334.205,0.000,V*01'
+      '$ECRMB,A,0.432,L,001,002,4653.550,N,07115.984,W,2.505,334.205,0.000,V*01',
     )
     delta.updates[0].values[4].value.should.be.closeTo(800.064, 0.005)
   })
@@ -77,7 +77,7 @@ describe('RMB', () => {
     const delta = new Parser().parse('$ECRMB,,,,,,,,,,,,,*77')
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.courseRhumbline.nextPoint.position'
+      'navigation.courseRhumbline.nextPoint.position',
     )
     delta.updates[0].values.should.containItemMatching({
       path: 'navigation.courseRhumbline.nextPoint.position',

--- a/test/RMC.js
+++ b/test/RMC.js
@@ -26,33 +26,33 @@ chai.use(require('./helpers/chai-has-item'))
 describe('RMC', () => {
   it('Converts OK using individual parser', () => {
     const delta = new Parser().parse(
-      '$GPRMC,085412.000,A,5222.3198,N,00454.5784,E,0.58,251.34,030414,,,A*65'
+      '$GPRMC,085412.000,A,5222.3198,N,00454.5784,E,0.58,251.34,030414,,,A*65',
     )
 
     delta.updates[0].timestamp.should.equal('2014-04-03T08:54:12.000Z')
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.position'
+      'navigation.position',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.courseOverGroundTrue'
+      'navigation.courseOverGroundTrue',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.speedOverGround'
+      'navigation.speedOverGround',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.magneticVariation'
+      'navigation.magneticVariation',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.magneticVariationAgeOfService'
+      'navigation.magneticVariationAgeOfService',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.datetime'
+      'navigation.datetime',
     )
     delta.updates[0].values
       .find((value) => value.path === 'navigation.position')
@@ -72,45 +72,45 @@ describe('RMC', () => {
     chai
       .expect(
         delta.updates[0].values.find(
-          (value) => value.path === 'navigation.magneticVariation'
-        ).value
+          (value) => value.path === 'navigation.magneticVariation',
+        ).value,
       )
       .to.be.a('null')
     delta.updates[0].values
       .find(
-        (value) => value.path === 'navigation.magneticVariationAgeOfService'
+        (value) => value.path === 'navigation.magneticVariationAgeOfService',
       )
       .value.should.equal(1396515252)
   })
 
   it('Converts OK using individual parser, w/ missing SOG/COG values', () => {
     const delta = new Parser().parse(
-      '$GPRMC,085412.000,A,5222.3198,N,00454.5784,E,,,030414,12,E*42'
+      '$GPRMC,085412.000,A,5222.3198,N,00454.5784,E,,,030414,12,E*42',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.speedOverGround'
+      'navigation.speedOverGround',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.courseOverGroundTrue'
+      'navigation.courseOverGroundTrue',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.magneticVariation'
+      'navigation.magneticVariation',
     )
     chai
       .expect(
         delta.updates[0].values.find(
-          (value) => value.path === 'navigation.courseOverGroundTrue'
-        ).value
+          (value) => value.path === 'navigation.courseOverGroundTrue',
+        ).value,
       )
       .to.be.a('null')
     chai
       .expect(
         delta.updates[0].values.find(
-          (value) => value.path === 'navigation.speedOverGround'
-        ).value
+          (value) => value.path === 'navigation.speedOverGround',
+        ).value,
       )
       .to.be.a('null')
     delta.updates[0].values
@@ -121,29 +121,29 @@ describe('RMC', () => {
   it('Converts OK using individual parser, w/ invalid lat/lng values', () => {
     const delta = new Parser().parse(
       // note that this particular example contains invalid latitude (1547\x0E70800) and invalid datestamp/magvar (110925\f12.49)
-      '$GPRMC,210735.00,A,1547\x0E70800,S,14506.50460,W,0.187,10.33,110925\f12.49,E,A*3E'
+      '$GPRMC,210735.00,A,1547\x0E70800,S,14506.50460,W,0.187,10.33,110925\f12.49,E,A*3E',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.position'
+      'navigation.position',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.speedOverGround'
+      'navigation.speedOverGround',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.courseOverGroundTrue'
+      'navigation.courseOverGroundTrue',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.datetime'
+      'navigation.datetime',
     )
     should.equal(
       delta.updates[0].values.find(
-        (value) => value.path === 'navigation.position'
+        (value) => value.path === 'navigation.position',
       ).value,
-      null
+      null,
     )
     delta.updates[0].values
       .find((value) => value.path === 'navigation.courseOverGroundTrue')

--- a/test/RMC.js
+++ b/test/RMC.js
@@ -21,7 +21,7 @@ const chai = require('chai')
 const should = chai.Should()
 
 chai.Should()
-chai.use(require('chai-things'))
+chai.use(require('./helpers/chai-has-item'))
 
 describe('RMC', () => {
   it('Converts OK using individual parser', () => {
@@ -30,27 +30,27 @@ describe('RMC', () => {
     )
 
     delta.updates[0].timestamp.should.equal('2014-04-03T08:54:12.000Z')
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.position'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.courseOverGroundTrue'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.speedOverGround'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.magneticVariation'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.magneticVariationAgeOfService'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.datetime'
     )
@@ -87,15 +87,15 @@ describe('RMC', () => {
     const delta = new Parser().parse(
       '$GPRMC,085412.000,A,5222.3198,N,00454.5784,E,,,030414,12,E*42'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.speedOverGround'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.courseOverGroundTrue'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.magneticVariation'
     )
@@ -123,19 +123,19 @@ describe('RMC', () => {
       // note that this particular example contains invalid latitude (1547\x0E70800) and invalid datestamp/magvar (110925\f12.49)
       '$GPRMC,210735.00,A,1547\x0E70800,S,14506.50460,W,0.187,10.33,110925\f12.49,E,A*3E'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.position'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.speedOverGround'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.courseOverGroundTrue'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.datetime'
     )

--- a/test/ROT.js
+++ b/test/ROT.js
@@ -22,12 +22,12 @@ const chai = require('chai')
 const nmeaLine = '$GPROT,35.6,A*01'
 
 chai.Should()
-chai.use(require('chai-things'))
+chai.use(require('./helpers/chai-has-item'))
 
 describe('ROT', () => {
   it('Converts OK using individual parser', () => {
     const delta = new Parser().parse(nmeaLine)
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.rateOfTurn'
     )

--- a/test/ROT.js
+++ b/test/ROT.js
@@ -29,11 +29,11 @@ describe('ROT', () => {
     const delta = new Parser().parse(nmeaLine)
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.rateOfTurn'
+      'navigation.rateOfTurn',
     )
     delta.updates[0].values[0].value.should.be.closeTo(
       ((35.6 / 180) * Math.PI) / 60,
-      0.0005
+      0.0005,
     )
   })
 })

--- a/test/RPM.js
+++ b/test/RPM.js
@@ -27,7 +27,7 @@ describe('RPM', () => {
 
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'propulsion.engine_1.revolutions'
+      'propulsion.engine_1.revolutions',
     )
     delta.updates[0].values[0].value.should.be.closeTo(2418.2 / 60, 0.0005)
   })

--- a/test/RPM.js
+++ b/test/RPM.js
@@ -17,7 +17,7 @@
 const Parser = require('../lib')
 const chai = require('chai')
 const should = chai.Should()
-chai.use(require('chai-things'))
+chai.use(require('./helpers/chai-has-item'))
 
 const nmeaLine = '$IIRPM,E,1,2418.2,10.5,A*5F'
 
@@ -25,7 +25,7 @@ describe('RPM', () => {
   it('Converts OK using individual parser', () => {
     const delta = new Parser().parse(nmeaLine)
 
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'propulsion.engine_1.revolutions'
     )

--- a/test/RSA.js
+++ b/test/RSA.js
@@ -22,12 +22,12 @@ const chai = require('chai')
 const nmeaLine = '$IIRSA,10.5,A,,V*4D'
 
 chai.Should()
-chai.use(require('chai-things'))
+chai.use(require('./helpers/chai-has-item'))
 
 describe('RSA', () => {
   it('Converts OK using individual parser', () => {
     const delta = new Parser().parse(nmeaLine)
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'steering.rudderAngle'
     )

--- a/test/RSA.js
+++ b/test/RSA.js
@@ -29,11 +29,11 @@ describe('RSA', () => {
     const delta = new Parser().parse(nmeaLine)
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'steering.rudderAngle'
+      'steering.rudderAngle',
     )
     delta.updates[0].values[0].value.should.be.closeTo(
       (10.5 / 180) * Math.PI,
-      0.1
+      0.1,
     )
   })
 })

--- a/test/VDM.js
+++ b/test/VDM.js
@@ -50,7 +50,7 @@ describe('VDM', function () {
       .value.should.equal(-27.5)
     delta.updates[0].values
       .find(
-        (pathValue) => pathValue.path === 'navigation.destination.commonName'
+        (pathValue) => pathValue.path === 'navigation.destination.commonName',
       )
       .value.should.equal('OOI SILEN')
     delta.updates[0].values
@@ -68,37 +68,37 @@ describe('VDM', function () {
 
   it('Single line converts ok', () => {
     const delta = new Parser().parse(
-      '!AIVDM,1,1,,A,13aEOK?P00PD2wVMdLDRhgvL289?,0*26\n'
+      '!AIVDM,1,1,,A,13aEOK?P00PD2wVMdLDRhgvL289?,0*26\n',
     )
     delta.context.should.equal('vessels.urn:mrn:imo:mmsi:244670316')
   })
 
   it("Unavailable values don't convert", () => {
     const delta = new Parser().parse(
-      '!AIVDM,1,1,,A,33@nwqwP?w<ovH0kOqP>4?wp0000,0*0B\n'
+      '!AIVDM,1,1,,A,33@nwqwP?w<ovH0kOqP>4?wp0000,0*0B\n',
     )
     delta.context.should.equal('vessels.urn:mrn:imo:mmsi:219004903')
 
     let findPath = should.not.exist(
       delta.updates[0].values.find((pv) => {
         return pv.path === 'navigation.headingTrue'
-      })
+      }),
     )
     should.not.exist(
       delta.updates[0].values.find((pv) => {
         return pv.path === 'navigation.courseOverGroundTrue'
-      })
+      }),
     )
     should.not.exist(
       delta.updates[0].values.find((pv) => {
         return pv.path === 'navigation.speedOverGround'
-      })
+      }),
     )
   })
 
   it('AtoN converts ok', () => {
     const delta = new Parser().parse(
-      '!AIVDM,1,1,,A,E>k`sUoJK@@@@@@@@@@@@@@@@@@MAhJS;@neP00000N000,0*0D\n'
+      '!AIVDM,1,1,,A,E>k`sUoJK@@@@@@@@@@@@@@@@@@MAhJS;@neP00000N000,0*0D\n',
     )
     delta.context.should.equal('atons.urn:mrn:imo:mmsi:993672087')
     delta.updates[0].values
@@ -133,7 +133,7 @@ describe('VDM', function () {
 
   it('SAR aircraft', () => {
     const delta = new Parser().parse(
-      '!AIVDM,1,1,,A,91b4uGhW1>QjIv@RMAgFlwh20<2L,0*72\n'
+      '!AIVDM,1,1,,A,91b4uGhW1>QjIv@RMAgFlwh20<2L,0*72\n',
     )
     delta.context.should.equal('aircraft.urn:mrn:imo:mmsi:111230303')
     delta.updates[0].values[3].path.should.equal('navigation.position')
@@ -142,14 +142,14 @@ describe('VDM', function () {
     delta.updates[0].values[1].path.should.equal('navigation.speedOverGround')
     delta.updates[0].values[1].value.should.equal(40.12667683209147)
     delta.updates[0].values[2].path.should.equal(
-      'navigation.courseOverGroundTrue'
+      'navigation.courseOverGroundTrue',
     )
     delta.updates[0].values[2].value.should.equal(3.049090203930291)
   })
 
   it('class B position report with non-AI talker', () => {
     const delta = new Parser().parse(
-      '!BSVDM,1,1,,A,B6CdCm0t3`tba35f@V9faHi7kP06,0*41\n'
+      '!BSVDM,1,1,,A,B6CdCm0t3`tba35f@V9faHi7kP06,0*41\n',
     )
     delta.updates[0].values
       .find((pathValue) => pathValue.path === 'sensors.ais.class')
@@ -163,7 +163,7 @@ describe('VDM', function () {
 
   it('class A position report with nav status motoring converts ok', () => {
     const delta = new Parser().parse(
-      '!AIVDM,1,1,,B,13aGra0P00PHid>NK9<2FOvHR624,0*3E\n'
+      '!AIVDM,1,1,,B,13aGra0P00PHid>NK9<2FOvHR624,0*3E\n',
     )
     delta.updates[0].values
       .find((pathValue) => pathValue.path === 'navigation.state')
@@ -175,7 +175,7 @@ describe('VDM', function () {
 
   it('Off Position AtoN converts ok', () => {
     const delta = new Parser().parse(
-      '!AIVDM,1,1,,A,E>k`sV6rKP00000000000000000=Al7t;A5E800000N@00,0*43\n'
+      '!AIVDM,1,1,,A,E>k`sV6rKP00000000000000000=Al7t;A5E800000N@00,0*43\n',
     )
     delta.updates[0].values
       .find((pathValue) => pathValue.path === 'offPosition')
@@ -184,7 +184,7 @@ describe('VDM', function () {
 
   it('class A position report with specialManeuver converts ok', () => {
     const delta = new Parser().parse(
-      '!AIVDM,1,1,,B,13aGra0P00PHid>NK9<2FOvHR624,0*3E\n'
+      '!AIVDM,1,1,,B,13aGra0P00PHid>NK9<2FOvHR624,0*3E\n',
     )
     delta.updates[0].values
       .find((pathValue) => pathValue.path === 'navigation.specialManeuver')
@@ -193,7 +193,7 @@ describe('VDM', function () {
 
   it('class A position report with specialManeuver converts ok', () => {
     const delta = new Parser().parse(
-      '!AIVDM,1,1,,B,13aGra0P00PHid>NK9<2FOvHR624,0*3E\n'
+      '!AIVDM,1,1,,B,13aGra0P00PHid>NK9<2FOvHR624,0*3E\n',
     )
     delta.updates[0].values
       .find((pathValue) => pathValue.path === 'navigation.specialManeuver')
@@ -202,7 +202,7 @@ describe('VDM', function () {
 
   it('msg type 8 converts ok', () => {
     const delta = new Parser().parse(
-      '!AIVDM,1,1,,A,85Mv070j2d>=<e<<=PQhhg`59P00,0*26'
+      '!AIVDM,1,1,,A,85Mv070j2d>=<e<<=PQhhg`59P00,0*26',
     )
     delta.context.should.equal('vessels.urn:mrn:imo:mmsi:366968860')
     delta.updates[0].values
@@ -215,7 +215,7 @@ describe('VDM', function () {
 
   it('virtual aton converts ok', () => {
     const delta = new Parser().parse(
-      '!AIVDM,1,1,,A,E02E340W6@1WPab3bPa200000000:uoH?9Ur000003v010,4*5C\n'
+      '!AIVDM,1,1,,A,E02E340W6@1WPab3bPa200000000:uoH?9Ur000003v010,4*5C\n',
     )
     delta.updates[0].values
       .find((pathValue) => pathValue.path === 'virtual')
@@ -225,7 +225,7 @@ describe('VDM', function () {
   it('imo conerts ok', () => {
     const parser = new Parser()
     let delta = parser.parse(
-      '!AIVDM,2,1,9,A,54hi<240?JU9`L<f220l4T@DhhF222222222220U5HD2:40Ht90000000000,0*60'
+      '!AIVDM,2,1,9,A,54hi<240?JU9`L<f220l4T@DhhF222222222220U5HD2:40Ht90000000000,0*60',
     )
     should.equal(delta, null)
 
@@ -239,7 +239,7 @@ describe('VDM', function () {
 
   it('meteo single sentence converts ok', () => {
     const delta = new Parser().parse(
-      '!AIVDM,1,1,,A,8@2R5Ph0GhOCT1a2VvkrgwvlFR06EuOwgqrqwnSwe7wvlOwwsAwwnSGmwvwt,0*40'
+      '!AIVDM,1,1,,A,8@2R5Ph0GhOCT1a2VvkrgwvlFR06EuOwgqrqwnSwe7wvlOwwsAwwnSGmwvwt,0*40',
     )
     delta.context.should.equal('meteo.urn:mrn:imo:mmsi:002655619:366097')
     const currentYear = new Date().getFullYear()
@@ -253,7 +253,7 @@ describe('VDM', function () {
     output.forEach(([path, value]) =>
       delta.updates[0].values
         .find((pathValue) => pathValue.path === path)
-        .value.should.equal(value)
+        .value.should.equal(value),
     )
   })
 
@@ -283,7 +283,7 @@ describe('VDM', function () {
     output.forEach(([path, value]) =>
       delta.updates[0].values
         .find((pathValue) => pathValue.path === path)
-        .value.should.equal(value)
+        .value.should.equal(value),
     )
   })
 })

--- a/test/VDM.js
+++ b/test/VDM.js
@@ -4,7 +4,6 @@ const Parser = require('../lib')
 const chai = require('chai')
 const should = chai.Should()
 
-chai.use(require('chai-things'))
 chai.use(require('@signalk/signalk-schema').chaiModule)
 const toFull = require('./toFull')
 

--- a/test/VDO.js
+++ b/test/VDO.js
@@ -25,7 +25,7 @@ describe('VDO', function () {
 
   it('Single line converts ok', () => {
     const delta = new Parser().parse(
-      '!AIVDM,1,1,,A,13aEOK?P00PD2wVMdLDRhgvL289?,0*26\n'
+      '!AIVDM,1,1,,A,13aEOK?P00PD2wVMdLDRhgvL289?,0*26\n',
     )
     delta.context.should.equal('vessels.urn:mrn:imo:mmsi:244670316')
   })

--- a/test/VDO.js
+++ b/test/VDO.js
@@ -4,8 +4,6 @@ const Parser = require('../lib')
 const chai = require('chai')
 const should = chai.Should()
 
-chai.use(require('chai-things'))
-
 const sentences = [
   '!AIVDM,2,1,0,A,53brRt4000010SG700iE@LE8@Tp4000000000153P615t0Ht0SCkjH4jC1C,0*25\n',
   '!AIVDM,2,2,0,A,`0000000001,2*75\n',

--- a/test/VDR.js
+++ b/test/VDR.js
@@ -20,7 +20,7 @@ const Parser = require('../lib')
 const chai = require('chai')
 
 chai.Should()
-chai.use(require('chai-things'))
+chai.use(require('./helpers/chai-has-item'))
 chai.use(require('@signalk/signalk-schema').chaiModule)
 const toFull = require('./toFull')
 
@@ -30,7 +30,7 @@ describe('VDR', () => {
   it('Converts OK using individual parser', () => {
     const delta = new Parser().parse(nmeaLine)
 
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'environment.current'
     )

--- a/test/VDR.js
+++ b/test/VDR.js
@@ -32,7 +32,7 @@ describe('VDR', () => {
 
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'environment.current'
+      'environment.current',
     )
     delta.updates[0].values[0].value.should.deep.equal({
       setTrue: 0.1762782544916768,

--- a/test/VHW.js
+++ b/test/VHW.js
@@ -20,13 +20,13 @@ const Parser = require('../lib')
 const chai = require('chai')
 const should = chai.Should()
 
-chai.use(require('chai-things'))
+chai.use(require('./helpers/chai-has-item'))
 
 describe('VHW', () => {
   it('speed data only', () => {
     const delta = new Parser().parse('$IIVHW,,T,,M,06.12,N,11.33,K*50')
 
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.speedThroughWater'
     )
@@ -36,12 +36,12 @@ describe('VHW', () => {
   it('speed & direction data', () => {
     const delta = new Parser().parse('$SDVHW,182.5,T,181.8,M,0.0,N,0.0,K*4C')
 
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.speedThroughWater'
     )
     delta.updates[0].values[2].value.should.be.closeTo(0, 0.00005)
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.headingMagnetic'
     )
@@ -49,7 +49,7 @@ describe('VHW', () => {
       3.1730085801256913,
       0.00005
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.headingTrue'
     )

--- a/test/VHW.js
+++ b/test/VHW.js
@@ -28,7 +28,7 @@ describe('VHW', () => {
 
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.speedThroughWater'
+      'navigation.speedThroughWater',
     )
     delta.updates[0].values[0].value.should.be.closeTo(3.148400797594869, 0.005)
   })
@@ -38,24 +38,24 @@ describe('VHW', () => {
 
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.speedThroughWater'
+      'navigation.speedThroughWater',
     )
     delta.updates[0].values[2].value.should.be.closeTo(0, 0.00005)
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.headingMagnetic'
+      'navigation.headingMagnetic',
     )
     delta.updates[0].values[1].value.should.be.closeTo(
       3.1730085801256913,
-      0.00005
+      0.00005,
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.headingTrue'
+      'navigation.headingTrue',
     )
     delta.updates[0].values[0].value.should.be.closeTo(
       3.1852258848896517,
-      0.00005
+      0.00005,
     )
   })
 

--- a/test/VLW.js
+++ b/test/VLW.js
@@ -22,13 +22,13 @@ const utils = require('@signalk/nmea0183-utilities')
 
 chai.Should()
 
-chai.use(require('chai-things'))
+chai.use(require('./helpers/chai-has-item'))
 
 describe('VLW', () => {
   it('total cumulative distance', () => {
     const delta = new Parser().parse('$IIVLW,10.1,N,3.2,N*7C')
 
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.log'
     )
@@ -41,7 +41,7 @@ describe('VLW', () => {
   it('trip distance', () => {
     const delta = new Parser().parse('$IIVLW,115.2,N,12.3,N*7A')
 
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.trip.log'
     )

--- a/test/VLW.js
+++ b/test/VLW.js
@@ -30,11 +30,11 @@ describe('VLW', () => {
 
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.log'
+      'navigation.log',
     )
     delta.updates[0].values[0].value.should.be.closeTo(
       10.1 * 1.852 * 1000,
-      0.001
+      0.001,
     )
   })
 
@@ -43,11 +43,11 @@ describe('VLW', () => {
 
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.trip.log'
+      'navigation.trip.log',
     )
     delta.updates[0].values[1].value.should.be.closeTo(
       12.3 * 1.852 * 1000,
-      0.001
+      0.001,
     )
   })
 })

--- a/test/VPW.js
+++ b/test/VPW.js
@@ -20,15 +20,15 @@ const nmeaLine = '$IIVPW,4.5,N,6.7,M*52'
 const nmeaLineKnots = '$IIVPW,4.5,N,,*30' // FIXME: add a test for knots?
 
 chai.Should()
-chai.use(require('chai-things'))
+chai.use(require('./helpers/chai-has-item'))
 
 describe('VPW', () => {
   it('Converts OK using individual parser', () => {
     const delta = new Parser().parse(nmeaLine)
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'performance.velocityMadeGood'
     )
-    delta.updates[0].values.should.contain.an.item.with.property('value', 6.7)
+    delta.updates[0].values.should.containItemWithProperty('value', 6.7)
   })
 })

--- a/test/VPW.js
+++ b/test/VPW.js
@@ -27,7 +27,7 @@ describe('VPW', () => {
     const delta = new Parser().parse(nmeaLine)
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'performance.velocityMadeGood'
+      'performance.velocityMadeGood',
     )
     delta.updates[0].values.should.containItemWithProperty('value', 6.7)
   })

--- a/test/VTG.js
+++ b/test/VTG.js
@@ -29,19 +29,19 @@ describe('VTG', () => {
 
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.courseOverGroundMagnetic'
+      'navigation.courseOverGroundMagnetic',
     )
     delta.updates[0].values[0].value.should.be.closeTo(6.271, 0.005)
 
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.courseOverGroundTrue'
+      'navigation.courseOverGroundTrue',
     )
     delta.updates[0].values[1].value.should.equal(0)
 
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.speedOverGround'
+      'navigation.speedOverGround',
     )
     delta.updates[0].values[2].value.should.equal(0)
   })
@@ -51,19 +51,19 @@ describe('VTG', () => {
 
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.courseOverGroundMagnetic'
+      'navigation.courseOverGroundMagnetic',
     )
     expect(delta.updates[0].values[0].value).to.be.null
 
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.courseOverGroundTrue'
+      'navigation.courseOverGroundTrue',
     )
     expect(delta.updates[0].values[1].value).to.be.null
 
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.speedOverGround'
+      'navigation.speedOverGround',
     )
     delta.updates[0].values[2].value.should.be.closeTo(0.0528, 0.00005)
   })

--- a/test/VTG.js
+++ b/test/VTG.js
@@ -21,25 +21,25 @@ const chai = require('chai')
 const expect = chai.expect
 
 chai.Should()
-chai.use(require('chai-things'))
+chai.use(require('./helpers/chai-has-item'))
 
 describe('VTG', () => {
   it('Converts OK using individual parser', () => {
     const delta = new Parser().parse('$GPVTG,0.0,T,359.3,M,0.0,N,0.0,K,A*2F')
 
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.courseOverGroundMagnetic'
     )
     delta.updates[0].values[0].value.should.be.closeTo(6.271, 0.005)
 
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.courseOverGroundTrue'
     )
     delta.updates[0].values[1].value.should.equal(0)
 
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.speedOverGround'
     )
@@ -49,19 +49,19 @@ describe('VTG', () => {
   it('Outputs nulls for missing values', () => {
     const delta = new Parser().parse('$GPVTG,,T,,M,0.102,N,0.190,K,A*28')
 
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.courseOverGroundMagnetic'
     )
     expect(delta.updates[0].values[0].value).to.be.null
 
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.courseOverGroundTrue'
     )
     expect(delta.updates[0].values[1].value).to.be.null
 
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.speedOverGround'
     )

--- a/test/VWR.js
+++ b/test/VWR.js
@@ -25,19 +25,19 @@ describe('VWR', () => {
 
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'environment.wind.angleApparent'
+      'environment.wind.angleApparent',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'value',
-      1.30899693929463
+      1.30899693929463,
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'environment.wind.speedApparent'
+      'environment.wind.speedApparent',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'value',
-      0.5144445747704034
+      0.5144445747704034,
     )
   })
 
@@ -46,19 +46,19 @@ describe('VWR', () => {
 
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'environment.wind.angleApparent'
+      'environment.wind.angleApparent',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'value',
-      -0.41887902057428156
+      -0.41887902057428156,
     )
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'environment.wind.speedApparent'
+      'environment.wind.speedApparent',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'value',
-      9.260002345867262
+      9.260002345867262,
     )
   })
 

--- a/test/VWR.js
+++ b/test/VWR.js
@@ -17,25 +17,25 @@
 const Parser = require('../lib')
 const chai = require('chai')
 const should = chai.Should()
-chai.use(require('chai-things'))
+chai.use(require('./helpers/chai-has-item'))
 
 describe('VWR', () => {
   it('Converts OK using individual parser', () => {
     const delta = new Parser().parse('$IIVWR,75,R,1.0,N,0.51,M,1.85,K*6C')
 
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'environment.wind.angleApparent'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'value',
       1.30899693929463
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'environment.wind.speedApparent'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'value',
       0.5144445747704034
     )
@@ -44,19 +44,19 @@ describe('VWR', () => {
   it('Handles shorter valid sentences', () => {
     const delta = new Parser().parse('$IIVWR,024,L,018,N,,,,*5e')
 
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'environment.wind.angleApparent'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'value',
       -0.41887902057428156
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'environment.wind.speedApparent'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'value',
       9.260002345867262
     )

--- a/test/VWT.js
+++ b/test/VWT.js
@@ -11,7 +11,7 @@ describe('VWT', () => {
     delta.updates[0].values[0].path.should.equal('environment.wind.speedTrue')
     delta.updates[0].values[0].value.should.equal(5.2)
     delta.updates[0].values[1].path.should.equal(
-      'environment.wind.angleTrueWater'
+      'environment.wind.angleTrueWater',
     )
     delta.updates[0].values[1].value.should.be.closeTo(0.523599, 0.005)
   })
@@ -22,7 +22,7 @@ describe('VWT', () => {
     delta.updates[0].values[0].path.should.equal('environment.wind.speedTrue')
     delta.updates[0].values[0].value.should.equal(5.2)
     delta.updates[0].values[1].path.should.equal(
-      'environment.wind.angleTrueWater'
+      'environment.wind.angleTrueWater',
     )
     delta.updates[0].values[1].value.should.be.closeTo(3.1415, 0.005)
   })
@@ -34,7 +34,7 @@ describe('VWT', () => {
     delta.updates[0].values[0].path.should.equal('environment.wind.speedTrue')
     delta.updates[0].values[0].value.should.equal(5.2)
     delta.updates[0].values[1].path.should.equal(
-      'environment.wind.angleTrueWater'
+      'environment.wind.angleTrueWater',
     )
     delta.updates[0].values[1].value.should.be.closeTo(-2.967, 0.005)
   })
@@ -45,7 +45,7 @@ describe('VWT', () => {
     delta.updates[0].values[0].path.should.equal('environment.wind.speedTrue')
     delta.updates[0].values[0].value.should.equal(5.2)
     delta.updates[0].values[1].path.should.equal(
-      'environment.wind.angleTrueWater'
+      'environment.wind.angleTrueWater',
     )
     delta.updates[0].values[1].value.should.be.closeTo(-2.967, 0.005)
   })
@@ -57,7 +57,7 @@ describe('VWT', () => {
     delta.updates[0].values[0].path.should.equal('environment.wind.speedTrue')
     delta.updates[0].values[0].value.should.equal(5.2)
     delta.updates[0].values[1].path.should.equal(
-      'environment.wind.angleTrueWater'
+      'environment.wind.angleTrueWater',
     )
     delta.updates[0].values[1].value.should.be.closeTo(-2.967, 0.005)
   })
@@ -68,7 +68,7 @@ describe('VWT', () => {
     delta.updates[0].values[0].path.should.equal('environment.wind.speedTrue')
     delta.updates[0].values[0].value.should.equal(5.2)
     delta.updates[0].values[1].path.should.equal(
-      'environment.wind.angleTrueWater'
+      'environment.wind.angleTrueWater',
     )
     delta.updates[0].values[1].value.should.be.closeTo(0.523599, 0.005)
   })
@@ -79,7 +79,7 @@ describe('VWT', () => {
     delta.updates[0].values[0].path.should.equal('environment.wind.speedTrue')
     delta.updates[0].values[0].value.should.be.closeTo(5.2, 0.05)
     delta.updates[0].values[1].path.should.equal(
-      'environment.wind.angleTrueWater'
+      'environment.wind.angleTrueWater',
     )
     delta.updates[0].values[1].value.should.be.closeTo(0.523599, 0.005)
   })
@@ -90,7 +90,7 @@ describe('VWT', () => {
     delta.updates[0].values[0].path.should.equal('environment.wind.speedTrue')
     delta.updates[0].values[0].value.should.be.closeTo(5.2, 0.05)
     delta.updates[0].values[1].path.should.equal(
-      'environment.wind.angleTrueWater'
+      'environment.wind.angleTrueWater',
     )
     delta.updates[0].values[1].value.should.be.closeTo(0.523599, 0.005)
   })
@@ -119,7 +119,7 @@ describe('VWT', () => {
     delta.updates[0].values[0].path.should.equal('environment.wind.speedTrue')
     delta.updates[0].values[0].value.should.equal(5.2)
     delta.updates[0].values[1].path.should.equal(
-      'environment.wind.angleTrueWater'
+      'environment.wind.angleTrueWater',
     )
     delta.updates[0].values[1].value.should.be.closeTo(0.523599, 0.005)
   })
@@ -130,7 +130,7 @@ describe('VWT', () => {
     delta.updates[0].values[0].path.should.equal('environment.wind.speedTrue')
     delta.updates[0].values[0].value.should.be.closeTo(5.2, 0.05)
     delta.updates[0].values[1].path.should.equal(
-      'environment.wind.angleTrueWater'
+      'environment.wind.angleTrueWater',
     )
     delta.updates[0].values[1].value.should.be.closeTo(0.523599, 0.005)
   })

--- a/test/VWT.js
+++ b/test/VWT.js
@@ -4,8 +4,6 @@ const Parser = require('../lib')
 const chai = require('chai')
 const should = chai.Should()
 
-chai.use(require('chai-things'))
-
 describe('VWT', () => {
   it('speed & direction data (#1)', () => {
     const delta = new Parser().parse('$IIVWT,030.,R,10.1,N,05.2,M,018.7,K*75')

--- a/test/XTE.js
+++ b/test/XTE.js
@@ -21,7 +21,6 @@ const chai = require('chai')
 const should = chai.Should()
 
 chai.Should()
-chai.use(require('chai-things'))
 
 describe('XTE', () => {
   it('Converts OK using individual parser', () => {

--- a/test/XTE.js
+++ b/test/XTE.js
@@ -29,7 +29,7 @@ describe('XTE', () => {
 
     delta.should.be.an('object')
     delta.updates[0].values[0].path.should.equal(
-      'navigation.courseRhumbline.crossTrackError'
+      'navigation.courseRhumbline.crossTrackError',
     )
     delta.updates[0].values[0].value.should.be.closeTo(1240.84, 0.001)
   })

--- a/test/ZDA.js
+++ b/test/ZDA.js
@@ -27,11 +27,11 @@ describe('ZDA', () => {
     const delta = new Parser().parse(nmeaLine)
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.datetime'
+      'navigation.datetime',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'value',
-      '2004-03-11T16:00:12.710Z'
+      '2004-03-11T16:00:12.710Z',
     )
   })
 
@@ -44,11 +44,11 @@ describe('ZDA', () => {
     const delta = new Parser().parse('$IIZDA,085400,22,07,2021,,*50')
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'navigation.datetime'
+      'navigation.datetime',
     )
     delta.updates[0].values.should.containItemWithProperty(
       'value',
-      '2021-07-22T08:54:00.000Z'
+      '2021-07-22T08:54:00.000Z',
     )
   })
 })

--- a/test/ZDA.js
+++ b/test/ZDA.js
@@ -17,7 +17,7 @@
 const Parser = require('../lib')
 const chai = require('chai')
 const should = chai.Should()
-chai.use(require('chai-things'))
+chai.use(require('./helpers/chai-has-item'))
 
 const nmeaLine = '$GPZDA,160012.71,11,03,2004,-1,00*7D'
 const emptyNmeaLine = '$GPZDA,,,,,,*48'
@@ -25,11 +25,11 @@ const emptyNmeaLine = '$GPZDA,,,,,,*48'
 describe('ZDA', () => {
   it('Converts OK using individual parser', () => {
     const delta = new Parser().parse(nmeaLine)
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.datetime'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'value',
       '2004-03-11T16:00:12.710Z'
     )
@@ -42,11 +42,11 @@ describe('ZDA', () => {
 
   it('Doesn\t choke when the number of seconds is 0', () => {
     const delta = new Parser().parse('$IIZDA,085400,22,07,2021,,*50')
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'navigation.datetime'
     )
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'value',
       '2021-07-22T08:54:00.000Z'
     )

--- a/test/customSentenceParser.js
+++ b/test/customSentenceParser.js
@@ -18,7 +18,6 @@ const Parser = require('../lib')
 const chai = require('chai')
 const { expect } = require('chai')
 const should = chai.Should()
-chai.use(require('chai-things'))
 
 describe('Custom Sentence Parser', () => {
   it('works', () => {

--- a/test/helpers/chai-has-item.js
+++ b/test/helpers/chai-has-item.js
@@ -42,7 +42,7 @@ module.exports = function chaiHasItem(chai, utils) {
         (checkValue ? ' = ' + JSON.stringify(value) : ''),
       value,
       undefined,
-      true
+      true,
     )
   })
 
@@ -66,7 +66,7 @@ module.exports = function chaiHasItem(chai, utils) {
         JSON.stringify(partial),
       partial,
       undefined,
-      true
+      true,
     )
   })
 }

--- a/test/helpers/chai-has-item.js
+++ b/test/helpers/chai-has-item.js
@@ -1,0 +1,72 @@
+'use strict'
+
+// Minimal chai plugin that replaces the two chai-things assertions used in
+// this repo's test suite. chai-things (last released 2014) only works with
+// the chai 4 plugin API, so it blocks upgrading chai to 5.x / 6.x.
+//
+// Provides two BDD-style assertions:
+//
+//   arr.should.containItemWithProperty('path', 'navigation.position')
+//     -> replaces: arr.should.contain.an.item.with.property('path', 'navigation.position')
+//
+//   arr.should.containItemMatching({ path: 'x', value: null })
+//     -> replaces: arr.should.contain.an.item({ path: 'x', value: null })
+//
+// Both assertions pass when at least one element in the array matches.
+// Property comparison uses chai's deep-equality helper so object and array
+// values work the same way chai-things used to handle them.
+
+module.exports = function chaiHasItem(chai, utils) {
+  const Assertion = chai.Assertion
+  const eql = utils.eql
+
+  Assertion.addMethod('containItemWithProperty', function (prop, value) {
+    const arr = this._obj
+    new Assertion(arr).to.be.an('array')
+
+    const checkValue = arguments.length >= 2
+    const matches = arr.filter(function (item) {
+      if (item == null || typeof item !== 'object') return false
+      if (!(prop in item)) return false
+      if (!checkValue) return true
+      return eql(item[prop], value)
+    })
+
+    this.assert(
+      matches.length > 0,
+      'expected #{this} to contain an item with property ' +
+        JSON.stringify(prop) +
+        (checkValue ? ' = ' + JSON.stringify(value) : ''),
+      'expected #{this} not to contain an item with property ' +
+        JSON.stringify(prop) +
+        (checkValue ? ' = ' + JSON.stringify(value) : ''),
+      value,
+      undefined,
+      true
+    )
+  })
+
+  Assertion.addMethod('containItemMatching', function (partial) {
+    const arr = this._obj
+    new Assertion(arr).to.be.an('array')
+    new Assertion(partial).to.be.an('object')
+
+    const keys = Object.keys(partial)
+    const matches = arr.filter(function (item) {
+      if (item == null || typeof item !== 'object') return false
+      return keys.every(function (k) {
+        return eql(item[k], partial[k])
+      })
+    })
+
+    this.assert(
+      matches.length > 0,
+      'expected #{this} to contain an item matching ' + JSON.stringify(partial),
+      'expected #{this} not to contain an item matching ' +
+        JSON.stringify(partial),
+      partial,
+      undefined,
+      true
+    )
+  })
+}

--- a/test/info.js
+++ b/test/info.js
@@ -20,7 +20,6 @@ const Parser = require('../lib')
 const chai = require('chai')
 const pkg = require('../package.json')
 chai.Should()
-chai.use(require('chai-things'))
 
 describe('Package info', () => {
   it(`Retrieves name "${pkg.name}" successfully`, (done) => {

--- a/test/invalid_checksum.js
+++ b/test/invalid_checksum.js
@@ -19,7 +19,6 @@
 const Parser = require('../lib')
 const chai = require('chai')
 const should = chai.Should()
-chai.use(require('chai-things'))
 
 const nmeaLine = '$GPROT,35.6,A*FF'
 

--- a/test/proprietary.js
+++ b/test/proprietary.js
@@ -19,7 +19,6 @@
 const Parser = require('../lib')
 const chai = require('chai')
 const should = chai.Should()
-chai.use(require('chai-things'))
 
 const nmeaLine = '$PMGNST,02.12,3,T,534,05.0,+03327,00*40'
 

--- a/test/seatalk.js
+++ b/test/seatalk.js
@@ -61,14 +61,14 @@ const waypointNameData = '82,05,27,D8,48,B7,06,F9'
 const waypointNameShortData = '82,05,91,6E,04,FB,00,FF'
 
 const should = chai.Should()
-chai.use(require('chai-things'))
+chai.use(require('./helpers/chai-has-item'))
 
 describe('seatalk', () => {
   ;['$PSMDST,', '$PSMDST,R,', '$STALK,'].forEach((prefix) => {
     it(`${prefix} 0x00 depth converted`, () => {
       const fullSentence = utils.appendChecksum(`${prefix}${depthData}`)
       const delta = new Parser().parse(fullSentence)
-      delta.updates[0].values.should.contain.an.item.with.property(
+      delta.updates[0].values.should.containItemWithProperty(
         'path',
         'environment.depth.belowTransducer'
       )
@@ -80,7 +80,7 @@ describe('seatalk', () => {
         `${prefix}${apparentWindAngleData}`
       )
       const delta = new Parser().parse(fullSentence)
-      delta.updates[0].values.should.contain.an.item.with.property(
+      delta.updates[0].values.should.containItemWithProperty(
         'path',
         'environment.wind.angleApparent'
       )
@@ -95,7 +95,7 @@ describe('seatalk', () => {
         `${prefix}${apparentWindSpeedData}`
       )
       const delta = new Parser().parse(fullSentence)
-      delta.updates[0].values.should.contain.an.item.with.property(
+      delta.updates[0].values.should.containItemWithProperty(
         'path',
         'environment.wind.speedApparent'
       )
@@ -110,7 +110,7 @@ describe('seatalk', () => {
         `${prefix}${speedThroughWaterData}`
       )
       const delta = new Parser().parse(fullSentence)
-      delta.updates[0].values.should.contain.an.item.with.property(
+      delta.updates[0].values.should.containItemWithProperty(
         'path',
         'navigation.speedThroughWater'
       )
@@ -125,7 +125,7 @@ describe('seatalk', () => {
         `${prefix}${speedThroughWaterDataGthex80}`
       )
       const delta = new Parser().parse(fullSentence)
-      delta.updates[0].values.should.contain.an.item.with.property(
+      delta.updates[0].values.should.containItemWithProperty(
         'path',
         'navigation.speedThroughWater'
       )
@@ -135,7 +135,7 @@ describe('seatalk', () => {
     it(`${prefix} 0x21 Trip converted`, () => {
       const fullSentence = utils.appendChecksum(`${prefix}${tripMileageData}`)
       const delta = new Parser().parse(fullSentence)
-      delta.updates[0].values.should.contain.an.item.with.property(
+      delta.updates[0].values.should.containItemWithProperty(
         'path',
         'navigation.trip'
       )
@@ -148,7 +148,7 @@ describe('seatalk', () => {
     it(`${prefix} 0x22 Total log converted`, () => {
       const fullSentence = utils.appendChecksum(`${prefix}${logData}`)
       const delta = new Parser().parse(fullSentence)
-      delta.updates[0].values.should.contain.an.item.with.property(
+      delta.updates[0].values.should.containItemWithProperty(
         'path',
         'navigation.log'
       )
@@ -160,7 +160,7 @@ describe('seatalk', () => {
         `${prefix}25,14,4C,BF,00,00,00}`
       )
       const delta = new Parser().parse(fullSentence)
-      delta.updates[0].values.should.contain.an.item.with.property(
+      delta.updates[0].values.should.containItemWithProperty(
         'path',
         'navigation.log'
       )
@@ -173,12 +173,12 @@ describe('seatalk', () => {
     it(`${prefix} 0x25 trip and log converted 1`, () => {
       const fullSentence = utils.appendChecksum(`${prefix}${tripAndLogData}`)
       const delta = new Parser().parse(fullSentence)
-      delta.updates[0].values.should.contain.an.item.with.property(
+      delta.updates[0].values.should.containItemWithProperty(
         'path',
         'navigation.trip'
       )
       delta.updates[0].values[0].value.should.be.closeTo(2665750.28, 0.5)
-      delta.updates[0].values.should.contain.an.item.with.property(
+      delta.updates[0].values.should.containItemWithProperty(
         'path',
         'navigation.log'
       )
@@ -190,7 +190,7 @@ describe('seatalk', () => {
         `${prefix}${averageSpeedThroughWaterData}`
       )
       const delta = new Parser().parse(fullSentence)
-      delta.updates[0].values.should.contain.an.item.with.property(
+      delta.updates[0].values.should.containItemWithProperty(
         'path',
         'navigation.averageSpeedThroughWater'
       )
@@ -202,7 +202,7 @@ describe('seatalk', () => {
         `${prefix}${waterTemperatureData}`
       )
       const delta = new Parser().parse(fullSentence)
-      delta.updates[0].values.should.contain.an.item.with.property(
+      delta.updates[0].values.should.containItemWithProperty(
         'path',
         'environment.water.temperature'
       )
@@ -217,7 +217,7 @@ describe('seatalk', () => {
 
       fullSentence = utils.appendChecksum(`${prefix}${longitudeData}`)
       delta = parser.parse(fullSentence)
-      delta.updates[0].values.should.contain.an.item.with.property(
+      delta.updates[0].values.should.containItemWithProperty(
         'path',
         'navigation.position'
       )
@@ -228,7 +228,7 @@ describe('seatalk', () => {
     it(`${prefix} 0x52 SOG converted`, () => {
       const fullSentence = utils.appendChecksum(`${prefix}${sogData}`)
       const delta = new Parser().parse(fullSentence)
-      delta.updates[0].values.should.contain.an.item.with.property(
+      delta.updates[0].values.should.containItemWithProperty(
         'path',
         'navigation.speedOverGround'
       )
@@ -238,7 +238,7 @@ describe('seatalk', () => {
     it(`${prefix} 0x53 COG converted`, () => {
       const fullSentence = utils.appendChecksum(`${prefix}${cogData}`)
       const delta = new Parser().parse(fullSentence)
-      delta.updates[0].values.should.contain.an.item.with.property(
+      delta.updates[0].values.should.containItemWithProperty(
         'path',
         'navigation.courseOverGroundMagnetic'
       )
@@ -256,7 +256,7 @@ describe('seatalk', () => {
         dateTag + utils.appendChecksum(`${prefix}${dateData}`)
       const delta = parser.parse(fullSentence)
 
-      delta.updates[0].values.should.contain.an.item.with.property(
+      delta.updates[0].values.should.containItemWithProperty(
         'path',
         'navigation.datetime'
       )
@@ -266,7 +266,7 @@ describe('seatalk', () => {
     it(`${prefix} 0x57 satelite info converted`, () => {
       const fullSentence = utils.appendChecksum(`${prefix}${satInfoData}`)
       const delta = new Parser().parse(fullSentence)
-      delta.updates[0].values.should.contain.an.item.with.property(
+      delta.updates[0].values.should.containItemWithProperty(
         'path',
         'navigation.gnss.satellites'
       )
@@ -276,7 +276,7 @@ describe('seatalk', () => {
     it(`${prefix} 0x84 heading converted`, () => {
       const fullSentence = utils.appendChecksum(`${prefix}${headingData}`)
       const delta = new Parser().parse(fullSentence)
-      delta.updates[0].values.should.contain.an.item.with.property(
+      delta.updates[0].values.should.containItemWithProperty(
         'path',
         'navigation.headingMagnetic'
       )
@@ -289,7 +289,7 @@ describe('seatalk', () => {
     it(`${prefix} 0x84 ap mode: standby converted`, () => {
       const fullSentence = utils.appendChecksum(`${prefix}${standbyData}`)
       const delta = new Parser().parse(fullSentence)
-      delta.updates[0].values.should.contain.an.item.with.property(
+      delta.updates[0].values.should.containItemWithProperty(
         'path',
         'steering.autopilot.state'
       )
@@ -299,7 +299,7 @@ describe('seatalk', () => {
     it(`${prefix} 0x84 ap mode: auto converted`, () => {
       const fullSentence = utils.appendChecksum(`${prefix}${autoData}`)
       const delta = new Parser().parse(fullSentence)
-      delta.updates[0].values.should.contain.an.item.with.property(
+      delta.updates[0].values.should.containItemWithProperty(
         'path',
         'steering.autopilot.target.headingMagnetic'
       )
@@ -308,7 +308,7 @@ describe('seatalk', () => {
         0.0005
       )
 
-      delta.updates[0].values.should.contain.an.item.with.property(
+      delta.updates[0].values.should.containItemWithProperty(
         'path',
         'steering.autopilot.state'
       )
@@ -318,7 +318,7 @@ describe('seatalk', () => {
     it(`${prefix} 0x84 ap mode: wind converted`, () => {
       const fullSentence = utils.appendChecksum(`${prefix}${windData}`)
       const delta = new Parser().parse(fullSentence)
-      delta.updates[0].values.should.contain.an.item.with.property(
+      delta.updates[0].values.should.containItemWithProperty(
         'path',
         'steering.autopilot.state'
       )
@@ -328,7 +328,7 @@ describe('seatalk', () => {
     it(`${prefix} 0x84 ap mode: route converted`, () => {
       const fullSentence = utils.appendChecksum(`${prefix}${routeData}`)
       const delta = new Parser().parse(fullSentence)
-      delta.updates[0].values.should.contain.an.item.with.property(
+      delta.updates[0].values.should.containItemWithProperty(
         'path',
         'steering.autopilot.state'
       )
@@ -338,7 +338,7 @@ describe('seatalk', () => {
     it(`${prefix} 0x84 rudder angle converted`, () => {
       const fullSentence = utils.appendChecksum(`${prefix}${rudderData}`)
       const delta = new Parser().parse(fullSentence)
-      delta.updates[0].values.should.contain.an.item.with.property(
+      delta.updates[0].values.should.containItemWithProperty(
         'path',
         'steering.rudderAngle'
       )
@@ -353,7 +353,7 @@ describe('seatalk', () => {
         `${prefix}${compassVariationData}`
       )
       const delta = new Parser().parse(fullSentence)
-      delta.updates[0].values.should.contain.an.item.with.property(
+      delta.updates[0].values.should.containItemWithProperty(
         'path',
         'navigation.magneticVariation'
       )
@@ -366,7 +366,7 @@ describe('seatalk', () => {
     it(`${prefix} 0x9C ap target heading  converted`, () => {
       const fullSentence = utils.appendChecksum(`${prefix}${heading_nineCData}`)
       const delta = new Parser().parse(fullSentence)
-      delta.updates[0].values.should.contain.an.item.with.property(
+      delta.updates[0].values.should.containItemWithProperty(
         'path',
         'navigation.headingMagnetic'
       )
@@ -393,15 +393,15 @@ describe('seatalk', () => {
     it(`${prefix} 0x85 navigation to waypoint converted`, () => {
       const fullSentence = utils.appendChecksum(`${prefix}${navToWaypointData}`)
       const delta = new Parser().parse(fullSentence)
-      delta.updates[0].values.should.contain.an.item.with.property(
+      delta.updates[0].values.should.containItemWithProperty(
         'path',
         'navigation.courseRhumbline.crossTrackError'
       )
-      delta.updates[0].values.should.contain.an.item.with.property(
+      delta.updates[0].values.should.containItemWithProperty(
         'path',
         'navigation.courseRhumbline.bearingToDestinationMagnetic'
       )
-      delta.updates[0].values.should.contain.an.item.with.property(
+      delta.updates[0].values.should.containItemWithProperty(
         'path',
         'navigation.courseRhumbline.nextPoint.distance'
       )
@@ -412,7 +412,7 @@ describe('seatalk', () => {
         `${prefix}${navToWaypointTrueData}`
       )
       const delta = new Parser().parse(fullSentence)
-      delta.updates[0].values.should.contain.an.item.with.property(
+      delta.updates[0].values.should.containItemWithProperty(
         'path',
         'navigation.courseRhumbline.bearingToDestinationTrue'
       )
@@ -421,7 +421,7 @@ describe('seatalk', () => {
     it(`${prefix} 0x82 waypoint name converted`, () => {
       const fullSentence = utils.appendChecksum(`${prefix}${waypointNameData}`)
       const delta = new Parser().parse(fullSentence)
-      delta.updates[0].values.should.contain.an.item.with.property(
+      delta.updates[0].values.should.containItemWithProperty(
         'path',
         'navigation.courseRhumbline.nextPoint.ID'
       )
@@ -433,7 +433,7 @@ describe('seatalk', () => {
         `${prefix}${waypointNameShortData}`
       )
       const delta = new Parser().parse(fullSentence)
-      delta.updates[0].values.should.contain.an.item.with.property(
+      delta.updates[0].values.should.containItemWithProperty(
         'path',
         'navigation.courseRhumbline.nextPoint.ID'
       )

--- a/test/seatalk.js
+++ b/test/seatalk.js
@@ -70,64 +70,64 @@ describe('seatalk', () => {
       const delta = new Parser().parse(fullSentence)
       delta.updates[0].values.should.containItemWithProperty(
         'path',
-        'environment.depth.belowTransducer'
+        'environment.depth.belowTransducer',
       )
       delta.updates[0].values[0].value.should.be.closeTo(266.33424, 0.0005)
     })
 
     it(`${prefix} 0x10 AWA converted`, () => {
       const fullSentence = utils.appendChecksum(
-        `${prefix}${apparentWindAngleData}`
+        `${prefix}${apparentWindAngleData}`,
       )
       const delta = new Parser().parse(fullSentence)
       delta.updates[0].values.should.containItemWithProperty(
         'path',
-        'environment.wind.angleApparent'
+        'environment.wind.angleApparent',
       )
       delta.updates[0].values[0].value.should.be.closeTo(
         2.373647783254262,
-        0.0005
+        0.0005,
       )
     })
 
     it(`${prefix} 0x11 AWS converted`, () => {
       const fullSentence = utils.appendChecksum(
-        `${prefix}${apparentWindSpeedData}`
+        `${prefix}${apparentWindSpeedData}`,
       )
       const delta = new Parser().parse(fullSentence)
       delta.updates[0].values.should.containItemWithProperty(
         'path',
-        'environment.wind.speedApparent'
+        'environment.wind.speedApparent',
       )
       delta.updates[0].values[0].value.should.be.closeTo(
         0.6173334897244841,
-        0.0005
+        0.0005,
       )
     })
 
     it(`${prefix} 0x20 STW converted`, () => {
       const fullSentence = utils.appendChecksum(
-        `${prefix}${speedThroughWaterData}`
+        `${prefix}${speedThroughWaterData}`,
       )
       const delta = new Parser().parse(fullSentence)
       delta.updates[0].values.should.containItemWithProperty(
         'path',
-        'navigation.speedThroughWater'
+        'navigation.speedThroughWater',
       )
       delta.updates[0].values[0].value.should.be.closeTo(
         2.6236673313290573,
-        0.0005
+        0.0005,
       )
     })
 
     it(`${prefix} 0x20 STW converted > 0x80`, () => {
       const fullSentence = utils.appendChecksum(
-        `${prefix}${speedThroughWaterDataGthex80}`
+        `${prefix}${speedThroughWaterDataGthex80}`,
       )
       const delta = new Parser().parse(fullSentence)
       delta.updates[0].values.should.containItemWithProperty(
         'path',
-        'navigation.speedThroughWater'
+        'navigation.speedThroughWater',
       )
       delta.updates[0].values[0].value.should.be.closeTo(6.636335, 0.0005)
     })
@@ -137,11 +137,11 @@ describe('seatalk', () => {
       const delta = new Parser().parse(fullSentence)
       delta.updates[0].values.should.containItemWithProperty(
         'path',
-        'navigation.trip'
+        'navigation.trip',
       )
       delta.updates[0].values[0].value.should.be.closeTo(
         2674917.68225763,
-        0.0005
+        0.0005,
       )
     })
 
@@ -150,23 +150,23 @@ describe('seatalk', () => {
       const delta = new Parser().parse(fullSentence)
       delta.updates[0].values.should.containItemWithProperty(
         'path',
-        'navigation.log'
+        'navigation.log',
       )
       delta.updates[0].values[0].value.should.be.closeTo(4086808.4, 0.5)
     })
 
     it(`${prefix} 0x25 trip and log converted 2`, () => {
       const fullSentence = utils.appendChecksum(
-        `${prefix}25,14,4C,BF,00,00,00}`
+        `${prefix}25,14,4C,BF,00,00,00}`,
       )
       const delta = new Parser().parse(fullSentence)
       delta.updates[0].values.should.containItemWithProperty(
         'path',
-        'navigation.log'
+        'navigation.log',
       )
       delta.updates[0].values[1].value.should.be.closeTo(
         utils.transform(11450.8, 'nm', 'm'),
-        0.5
+        0.5,
       )
     })
 
@@ -175,36 +175,36 @@ describe('seatalk', () => {
       const delta = new Parser().parse(fullSentence)
       delta.updates[0].values.should.containItemWithProperty(
         'path',
-        'navigation.trip'
+        'navigation.trip',
       )
       delta.updates[0].values[0].value.should.be.closeTo(2665750.28, 0.5)
       delta.updates[0].values.should.containItemWithProperty(
         'path',
-        'navigation.log'
+        'navigation.log',
       )
       delta.updates[0].values[1].value.should.be.closeTo(52550314.8, 0.5)
     })
 
     it(`${prefix} 0x26 STW converted`, () => {
       const fullSentence = utils.appendChecksum(
-        `${prefix}${averageSpeedThroughWaterData}`
+        `${prefix}${averageSpeedThroughWaterData}`,
       )
       const delta = new Parser().parse(fullSentence)
       delta.updates[0].values.should.containItemWithProperty(
         'path',
-        'navigation.averageSpeedThroughWater'
+        'navigation.averageSpeedThroughWater',
       )
       delta.updates[0].values[0].value.should.be.closeTo(22.47, 0.5)
     })
 
     it(`${prefix} 0x27 Water temperature converted`, () => {
       const fullSentence = utils.appendChecksum(
-        `${prefix}${waterTemperatureData}`
+        `${prefix}${waterTemperatureData}`,
       )
       const delta = new Parser().parse(fullSentence)
       delta.updates[0].values.should.containItemWithProperty(
         'path',
-        'environment.water.temperature'
+        'environment.water.temperature',
       )
       delta.updates[0].values[0].value.should.be.closeTo(288.9, 0.5)
     })
@@ -219,7 +219,7 @@ describe('seatalk', () => {
       delta = parser.parse(fullSentence)
       delta.updates[0].values.should.containItemWithProperty(
         'path',
-        'navigation.position'
+        'navigation.position',
       )
       delta.updates[0].values[0].value['latitude'].should.be.closeTo(33, 0.5)
       delta.updates[0].values[0].value['longitude'].should.be.closeTo(-33, 0.5)
@@ -230,7 +230,7 @@ describe('seatalk', () => {
       const delta = new Parser().parse(fullSentence)
       delta.updates[0].values.should.containItemWithProperty(
         'path',
-        'navigation.speedOverGround'
+        'navigation.speedOverGround',
       )
       delta.updates[0].values[0].value.should.be.closeTo(0.103, 0.005)
     })
@@ -240,7 +240,7 @@ describe('seatalk', () => {
       const delta = new Parser().parse(fullSentence)
       delta.updates[0].values.should.containItemWithProperty(
         'path',
-        'navigation.courseOverGroundMagnetic'
+        'navigation.courseOverGroundMagnetic',
       )
       delta.updates[0].values[0].value.should.be.closeTo(2.7576, 0.005)
     })
@@ -258,7 +258,7 @@ describe('seatalk', () => {
 
       delta.updates[0].values.should.containItemWithProperty(
         'path',
-        'navigation.datetime'
+        'navigation.datetime',
       )
       delta.updates[0].values[0].value.should.equal('2024-04-04T17:08:34.000Z')
     })
@@ -268,7 +268,7 @@ describe('seatalk', () => {
       const delta = new Parser().parse(fullSentence)
       delta.updates[0].values.should.containItemWithProperty(
         'path',
-        'navigation.gnss.satellites'
+        'navigation.gnss.satellites',
       )
       delta.updates[0].values[0].value.should.equal(7)
     })
@@ -278,11 +278,11 @@ describe('seatalk', () => {
       const delta = new Parser().parse(fullSentence)
       delta.updates[0].values.should.containItemWithProperty(
         'path',
-        'navigation.headingMagnetic'
+        'navigation.headingMagnetic',
       )
       delta.updates[0].values[0].value.should.be.closeTo(
         5.305800926062761,
-        0.0005
+        0.0005,
       )
     })
 
@@ -291,7 +291,7 @@ describe('seatalk', () => {
       const delta = new Parser().parse(fullSentence)
       delta.updates[0].values.should.containItemWithProperty(
         'path',
-        'steering.autopilot.state'
+        'steering.autopilot.state',
       )
       delta.updates[0].values[1].value.should.equal('standby')
     })
@@ -301,16 +301,16 @@ describe('seatalk', () => {
       const delta = new Parser().parse(fullSentence)
       delta.updates[0].values.should.containItemWithProperty(
         'path',
-        'steering.autopilot.target.headingMagnetic'
+        'steering.autopilot.target.headingMagnetic',
       )
       delta.updates[0].values[1].value.should.be.closeTo(
         2.626720524251466,
-        0.0005
+        0.0005,
       )
 
       delta.updates[0].values.should.containItemWithProperty(
         'path',
-        'steering.autopilot.state'
+        'steering.autopilot.state',
       )
       delta.updates[0].values[2].value.should.equal('auto')
     })
@@ -320,7 +320,7 @@ describe('seatalk', () => {
       const delta = new Parser().parse(fullSentence)
       delta.updates[0].values.should.containItemWithProperty(
         'path',
-        'steering.autopilot.state'
+        'steering.autopilot.state',
       )
       delta.updates[0].values[0].value.should.equal('wind')
     })
@@ -330,7 +330,7 @@ describe('seatalk', () => {
       const delta = new Parser().parse(fullSentence)
       delta.updates[0].values.should.containItemWithProperty(
         'path',
-        'steering.autopilot.state'
+        'steering.autopilot.state',
       )
       delta.updates[0].values[0].value.should.equal('route')
     })
@@ -340,26 +340,26 @@ describe('seatalk', () => {
       const delta = new Parser().parse(fullSentence)
       delta.updates[0].values.should.containItemWithProperty(
         'path',
-        'steering.rudderAngle'
+        'steering.rudderAngle',
       )
       delta.updates[0].values[0].value.should.be.closeTo(
         -0.03490658503988659,
-        0.0005
+        0.0005,
       )
     })
 
     it(`${prefix} 0x99 compass variation converted`, () => {
       const fullSentence = utils.appendChecksum(
-        `${prefix}${compassVariationData}`
+        `${prefix}${compassVariationData}`,
       )
       const delta = new Parser().parse(fullSentence)
       delta.updates[0].values.should.containItemWithProperty(
         'path',
-        'navigation.magneticVariation'
+        'navigation.magneticVariation',
       )
       delta.updates[0].values[0].value.should.be.closeTo(
         1.0646508439596323,
-        0.0005
+        0.0005,
       )
     })
 
@@ -368,11 +368,11 @@ describe('seatalk', () => {
       const delta = new Parser().parse(fullSentence)
       delta.updates[0].values.should.containItemWithProperty(
         'path',
-        'navigation.headingMagnetic'
+        'navigation.headingMagnetic',
       )
       delta.updates[0].values[0].value.should.be.closeTo(
         2.6529004630313806,
-        0.0005
+        0.0005,
       )
     })
 
@@ -384,7 +384,7 @@ describe('seatalk', () => {
 
     it(`${prefix} Doesn\'t choke on empty 0x84 sentences`, () => {
       const fullSentence = utils.appendChecksum(
-        `${prefix}${empty_eightFourData}`
+        `${prefix}${empty_eightFourData}`,
       )
       const delta = new Parser().parse(fullSentence)
       should.equal(delta, null)
@@ -395,26 +395,26 @@ describe('seatalk', () => {
       const delta = new Parser().parse(fullSentence)
       delta.updates[0].values.should.containItemWithProperty(
         'path',
-        'navigation.courseRhumbline.crossTrackError'
+        'navigation.courseRhumbline.crossTrackError',
       )
       delta.updates[0].values.should.containItemWithProperty(
         'path',
-        'navigation.courseRhumbline.bearingToDestinationMagnetic'
+        'navigation.courseRhumbline.bearingToDestinationMagnetic',
       )
       delta.updates[0].values.should.containItemWithProperty(
         'path',
-        'navigation.courseRhumbline.nextPoint.distance'
+        'navigation.courseRhumbline.nextPoint.distance',
       )
     })
 
     it(`${prefix} 0x85 navigation to waypoint with true bearing converted`, () => {
       const fullSentence = utils.appendChecksum(
-        `${prefix}${navToWaypointTrueData}`
+        `${prefix}${navToWaypointTrueData}`,
       )
       const delta = new Parser().parse(fullSentence)
       delta.updates[0].values.should.containItemWithProperty(
         'path',
-        'navigation.courseRhumbline.bearingToDestinationTrue'
+        'navigation.courseRhumbline.bearingToDestinationTrue',
       )
     })
 
@@ -423,19 +423,19 @@ describe('seatalk', () => {
       const delta = new Parser().parse(fullSentence)
       delta.updates[0].values.should.containItemWithProperty(
         'path',
-        'navigation.courseRhumbline.nextPoint.ID'
+        'navigation.courseRhumbline.nextPoint.ID',
       )
       delta.updates[0].values[0].value.should.equal('WPT1')
     })
 
     it(`${prefix} 0x82 short waypoint name converted`, () => {
       const fullSentence = utils.appendChecksum(
-        `${prefix}${waypointNameShortData}`
+        `${prefix}${waypointNameShortData}`,
       )
       const delta = new Parser().parse(fullSentence)
       delta.updates[0].values.should.containItemWithProperty(
         'path',
-        'navigation.courseRhumbline.nextPoint.ID'
+        'navigation.courseRhumbline.nextPoint.ID',
       )
       delta.updates[0].values[0].value.should.equal('AB')
     })

--- a/test/tagblock.js
+++ b/test/tagblock.js
@@ -19,7 +19,7 @@
 const Parser = require('../lib')
 const chai = require('chai')
 chai.Should()
-chai.use(require('chai-things'))
+chai.use(require('./helpers/chai-has-item'))
 
 const nmeaLine =
   '\\s:compass,c:1438489697*13\\$IIDBT,035.53,f,010.83,M,005.85,F*23'
@@ -31,7 +31,7 @@ describe('NMEA0183v4 tag block', () => {
     delta.updates[0].source.should.be.an('object')
     delta.updates[0].source.talker.should.equal('compass')
     delta.updates[0].timestamp.should.equal('2015-08-02T04:28:17.000Z')
-    delta.updates[0].values.should.contain.an.item.with.property(
+    delta.updates[0].values.should.containItemWithProperty(
       'path',
       'environment.depth.belowTransducer'
     )

--- a/test/tagblock.js
+++ b/test/tagblock.js
@@ -33,7 +33,7 @@ describe('NMEA0183v4 tag block', () => {
     delta.updates[0].timestamp.should.equal('2015-08-02T04:28:17.000Z')
     delta.updates[0].values.should.containItemWithProperty(
       'path',
-      'environment.depth.belowTransducer'
+      'environment.depth.belowTransducer',
     )
   })
 })


### PR DESCRIPTION
## Summary

Unblocks the two devDependency majors that `.github/dependabot.yml` currently ignores:

- **chai 4 → 6** (and removes the abandoned `chai-things` plugin)
- **prettier 2 → 3** (and runs the resulting tree-wide reformat)

Supersedes #286 and #287 (both closed pending this work).

### chai 4 → 6

`chai-things` (last released 2014) only works with chai's v4 plugin API, so bumping chai broke every test that used `.should.contain.an.item...`. The test suite only used two `chai-things` assertions:

```js
arr.should.contain.an.item.with.property('path', 'x')
arr.should.contain.an.item({ path: 'x', value: null })
```

Replaced `chai-things` with a ~70-line local plugin (`test/helpers/chai-has-item.js`) that provides `containItemWithProperty` and `containItemMatching` with identical semantics, and rewrote the 31 test files that used them. Dropped the now-unused `chai.use(require('chai-things'))` line from 14 files that imported it without using the pattern.

### prettier 2 → 3

Prettier 3 changes several defaults (trailing commas by default, etc.). Ran `npm run prettier` across the tree so the reformat lands as a single reviewable commit rather than being sprinkled through unrelated PRs going forward.

### Cleanup

Both `chai` and `prettier` major-version entries are removed from `.github/dependabot.yml`'s ignore list so future majors flow through the normal weekly bump.

## Test plan

- [x] `npm test` — all 241 tests pass
- [x] `npm run prettier:check` — clean