### PR TITLE
fix: parse TO/FROM waypoint IDs in RMB sentences

### DIFF
--- a/hooks/RMB.js
+++ b/hooks/RMB.js
@@ -75,37 +75,56 @@ module.exports = function (input) {
 
   crossTrackError = parts[2] == 'L' ? crossTrackError : -crossTrackError
 
+  const originWaypointID = (parts[3] || '').trim()
+  const destinationWaypointID = (parts[4] || '').trim()
+
+  const values = [
+    {
+      path: 'navigation.courseRhumbline.nextPoint.position',
+      value: position
+    },
+
+    {
+      path: 'navigation.courseRhumbline.nextPoint.bearingTrue',
+      value: utils.transform(bearing, 'deg', 'rad')
+    },
+
+    {
+      path: 'navigation.courseRhumbline.nextPoint.velocityMadeGood',
+      value: utils.transform(vmg, 'knots', 'ms')
+    },
+
+    {
+      path: 'navigation.courseRhumbline.nextPoint.distance',
+      value: utils.transform(distance, 'nm', 'km') * 1000
+    },
+
+    {
+      path: 'navigation.courseRhumbline.crossTrackError',
+      value: utils.transform(crossTrackError, 'nm', 'km') * 1000
+    }
+  ]
+
+  if (destinationWaypointID) {
+    values.push({
+      path: 'navigation.courseRhumbline.nextPoint.ID',
+      value: destinationWaypointID
+    })
+  }
+
+  if (originWaypointID) {
+    values.push({
+      path: 'navigation.courseRhumbline.previousPoint.ID',
+      value: originWaypointID
+    })
+  }
+
   const delta = {
     updates: [
       {
         source: tags.source,
         timestamp: tags.timestamp,
-        values: [
-          {
-            path: 'navigation.courseRhumbline.nextPoint.position',
-            value: position
-          },
-
-          {
-            path: 'navigation.courseRhumbline.nextPoint.bearingTrue',
-            value: utils.transform(bearing, 'deg', 'rad')
-          },
-
-          {
-            path: 'navigation.courseRhumbline.nextPoint.velocityMadeGood',
-            value: utils.transform(vmg, 'knots', 'ms')
-          },
-
-          {
-            path: 'navigation.courseRhumbline.nextPoint.distance',
-            value: utils.transform(distance, 'nm', 'km') * 1000
-          },
-
-          {
-            path: 'navigation.courseRhumbline.crossTrackError',
-            value: utils.transform(crossTrackError, 'nm', 'km') * 1000
-          }
-        ]
+        values
       }
     ]
   }

--- a/test/RMB.js
+++ b/test/RMB.js
@@ -57,6 +57,15 @@ describe('RMB', () => {
     delta.updates[0].values[2].value.should.be.closeTo(0, 0.005)
     delta.updates[0].values[3].value.should.be.closeTo(4639.26, 0.005)
     delta.updates[0].values[4].value.should.equal(0)
+
+    delta.updates[0].values.should.containItemMatching({
+      path: 'navigation.courseRhumbline.nextPoint.ID',
+      value: '002'
+    })
+    delta.updates[0].values.should.containItemMatching({
+      path: 'navigation.courseRhumbline.previousPoint.ID',
+      value: '001'
+    })
   })
 
   it('crossTrackError should be negative to steer right', () => {
@@ -73,15 +82,47 @@ describe('RMB', () => {
     delta.updates[0].values[4].value.should.be.closeTo(800.064, 0.005)
   })
 
+  it('omits waypoint IDs when fields are empty', () => {
+    const delta = new Parser().parse(
+      '$ECRMB,A,0.000,L,,,4653.550,N,07115.984,W,2.505,334.205,0.000,V*07'
+    )
+    const paths = delta.updates[0].values.map((v) => v.path)
+    paths.should.not.include('navigation.courseRhumbline.nextPoint.ID')
+    paths.should.not.include('navigation.courseRhumbline.previousPoint.ID')
+  })
+
+  it('includes only destination ID when origin is empty', () => {
+    const delta = new Parser().parse(
+      '$ECRMB,A,0.000,L,,002,4653.550,N,07115.984,W,2.505,334.205,0.000,V*35'
+    )
+    delta.updates[0].values.should.containItemMatching({
+      path: 'navigation.courseRhumbline.nextPoint.ID',
+      value: '002'
+    })
+    const paths = delta.updates[0].values.map((v) => v.path)
+    paths.should.not.include('navigation.courseRhumbline.previousPoint.ID')
+  })
+
+  it('includes only origin ID when destination is empty', () => {
+    const delta = new Parser().parse(
+      '$ECRMB,A,0.000,L,001,,4653.550,N,07115.984,W,2.505,334.205,0.000,V*36'
+    )
+    delta.updates[0].values.should.containItemMatching({
+      path: 'navigation.courseRhumbline.previousPoint.ID',
+      value: '001'
+    })
+    const paths = delta.updates[0].values.map((v) => v.path)
+    paths.should.not.include('navigation.courseRhumbline.nextPoint.ID')
+  })
+
   it("Doesn't choke on empty sentences", () => {
     const delta = new Parser().parse('$ECRMB,,,,,,,,,,,,,*77')
-    delta.updates[0].values.should.containItemWithProperty(
-      'path',
-      'navigation.courseRhumbline.nextPoint.position'
-    )
     delta.updates[0].values.should.containItemMatching({
       path: 'navigation.courseRhumbline.nextPoint.position',
       value: null
     })
+    const paths = delta.updates[0].values.map((v) => v.path)
+    paths.should.not.include('navigation.courseRhumbline.nextPoint.ID')
+    paths.should.not.include('navigation.courseRhumbline.previousPoint.ID')
   })
 })


### PR DESCRIPTION
## Summary

- Parse RMB fields 3 (origin waypoint ID) and 4 (destination waypoint ID) into `navigation.courseRhumbline.previousPoint.ID` and `nextPoint.ID`, matching the existing BOD/APB convention
- Empty waypoint IDs are omitted from the delta rather than published as empty strings
- Adds tests for both IDs present, both empty, and each ID individually present/absent

Closes SignalK/signalk-to-nmea0183#150

## Test plan

- [x] 244/244 unit tests pass (`npm test`)
- [x] Integration test passes inside `signalk/signalk-server:latest` Docker container
- [x] Verified field mapping matches BOD (`hooks/BOD.js`) and APB (`hooks/APB.js`) conventions
- [ ] Verify on a real vessel with active route navigation