### PR TITLE
chore(deps): bump @signalk/nmea0183-utilities to ^0.12.0

### DIFF
--- a/hooks/RMB.js
+++ b/hooks/RMB.js
@@ -50,11 +50,9 @@ module.exports = function (input) {
   let crossTrackError = 0.0
   let position = null
 
-  latitude = utils.coordinate(parts[5], parts[6])
-  longitude = utils.coordinate(parts[7], parts[8])
-  if (isNaN(latitude) || isNaN(longitude)) {
-    position = null
-  } else {
+  if (parts[5].trim() !== '' && parts[7].trim() !== '') {
+    latitude = utils.coordinate(parts[5], parts[6])
+    longitude = utils.coordinate(parts[7], parts[8])
     position = {
       longitude,
       latitude

--- a/hooks/ZDA.js
+++ b/hooks/ZDA.js
@@ -66,17 +66,6 @@ module.exports = function (input) {
 
   var delta = {}
   if (time.length >= 6 && date.length === 6 && empty < 3) {
-    const year = parts[3]
-    const month = parts[2] - 1
-    const day = parts[1]
-    const hour = (parts[0] || '').substring(0, 2)
-    const minute = (parts[0] || '').substring(2, 4)
-    const second = (parts[0] || '').substring(4, 6)
-    const milliSecond = (parts[0].substring(4) % 1) * 1000
-    const d = new Date(
-      Date.UTC(year, month, day, hour, minute, second, milliSecond)
-    )
-    const ts = d.toISOString()
     delta = {
       updates: [
         {
@@ -85,7 +74,7 @@ module.exports = function (input) {
           values: [
             {
               path: 'navigation.datetime',
-              value: ts
+              value: utils.timestamp(time, date)
             }
           ]
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.17.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@signalk/nmea0183-utilities": "^0.10.0",
+        "@signalk/nmea0183-utilities": "^0.12.0",
         "@signalk/signalk-schema": "^1.7.1",
         "ggencoder": "^1.0.8",
         "split": "^1.0.1"
@@ -537,9 +537,9 @@
       }
     },
     "node_modules/@signalk/nmea0183-utilities": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@signalk/nmea0183-utilities/-/nmea0183-utilities-0.10.0.tgz",
-      "integrity": "sha512-rQWKHfivXGjsrNSgXiLfHkUJqIwuWprbyot/Gf/AI9zfU8lc2G85HafBNSdr+FFnsMjwDK6WILXWskEhInO7NA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@signalk/nmea0183-utilities/-/nmea0183-utilities-0.12.0.tgz",
+      "integrity": "sha512-kARrM9DN+Kj51FoiUHnUNLL97GwWF4t+O5SovaZ+BHr76iwxjBlxJ5TV8lXgvNcu3UvxPVJHP/uygeuJJWKbXA==",
       "license": "Apache-2.0"
     },
     "node_modules/@signalk/signalk-schema": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "Fabian Tollenaar <fabian@signalk.org> (http://signalk.org)",
   "license": "Apache-2.0",
   "dependencies": {
-    "@signalk/nmea0183-utilities": "^0.10.0",
+    "@signalk/nmea0183-utilities": "^0.12.0",
     "@signalk/signalk-schema": "^1.7.1",
     "ggencoder": "^1.0.8",
     "split": "^1.0.1"


### PR DESCRIPTION
## Summary

- Bumps `@signalk/nmea0183-utilities` from `^0.10.0` → `^0.12.0` (lockfile resolved 0.10.0 → 0.12.0).
- **hooks/ZDA.js**: drops the inline `(parts[0].substring(4) % 1) * 1000` millisecond computation. Upstream `utils.timestamp` now preserves fractional seconds (SignalK/nmea0183-utilities#51, released as v0.12.0), so ZDA can just call `utils.timestamp(time, date)` like every other hook. -15 lines.
- **hooks/RMB.js**: explicit empty-string guard before building `position`. Details below.

## Why the RMB change is bundled here

v0.11.0 of nmea0183-utilities (SignalK/nmea0183-utilities#40) changed `utils.int` / `utils.float` to return `0` instead of `NaN` for unparseable input. The RMB hook was using `isNaN(latitude) || isNaN(longitude)` as an empty-sentence sentinel, so after the bump empty coords silently build `{longitude: 0, latitude: 0}` — Null Island — instead of `null`. The `test/RMB.js` "Doesn't choke on empty sentences" test caught this immediately once the lockfile resolved to 0.12.0.

The previous `^0.10.0` range already allowed 0.11.x/0.12.x, but the lockfile pinned 0.10.0 so the regression was latent on master. This PR is the first time it surfaces — including the fix here keeps CI green and matches the empty-guard pattern already used by `hooks/RMC.js`.

## Test plan

- [x] `npm ci && npm test` — 241 passing (unchanged from master baseline), RMB empty-sentence test now passes with 0.12.0 resolved.
- [x] `npm run prettier:check` — clean.
- [x] ZDA test asserts `2004-03-11T16:00:12.710Z` for `$GPZDA,160012.71,...` — the ms preservation round-trips end-to-end through the new util.

## Scope notes

I checked the other coordinate consumers (BWC, BWR, GGA, GLL, GNS, RMC). They either short-circuit before calling `utils.coordinate` (RMC, GGA/GLL/GNS via `isValidPosition` / explicit position return) or their empty tests assert a different shape that happens to still pass. No silent (0, 0) regressions in this bump beyond RMB — leaving those untouched.