### PR TITLE
fix(DSC): use `sentence` instead of undefined `line` in unhandled-message branch

### DIFF
--- a/hooks/DSC.js
+++ b/hooks/DSC.js
@@ -180,11 +180,11 @@ module.exports = function (input) {
     })
   }
   if (!handled) {
-    console.log('DSC Message Not Handled: ' + line)
+    debug('DSC Message Not Handled: ' + sentence)
     values.push({
       path: 'notifications.dsc_parser',
       value: {
-        message: 'DSC Message Not Handled: ' + line
+        message: 'DSC Message Not Handled: ' + sentence
       }
     })
   }

--- a/test/DSC.js
+++ b/test/DSC.js
@@ -7,6 +7,11 @@ const nmeaLinePos = '$CDDSC,20,3381581370,00,21,26,1423108312,1902,,,B,E*7B'
 const nmeaLineDistress =
   '$CDDSC,12,3380400790,12,06,00,1423108312,2019,,,S,E*6A'
 const emptyNmeaLine = '$CDDSC,,,,,,,,,,,*7F'
+// Routine category (parts[2]='00') with a telecommand (parts[3]='22') the
+// parser doesn't currently map — exercises the "not handled" branch which
+// used to throw ReferenceError (line undefined).
+const nmeaLineUnhandled =
+  '$CDDSC,20,3381581370,00,22,26,1423108312,1902,,,B,E*78'
 
 describe('DSC', () => {
   it('Position converts ok', () => {
@@ -36,5 +41,15 @@ describe('DSC', () => {
   it("Doesn't choke on empty sentences", () => {
     const delta = new Parser().parse(emptyNmeaLine)
     should.equal(delta, null)
+  })
+
+  it('Unhandled sentence produces a notification without throwing', () => {
+    const delta = new Parser().parse(nmeaLineUnhandled)
+
+    delta.updates[0].values.should.containItemWithProperty(
+      'path',
+      'notifications.dsc_parser'
+    )
+    delta.context.should.equal('vessels.urn:mrn:imo:mmsi:338158137')
   })
 })


### PR DESCRIPTION
## Summary

When a DSC sentence falls into the \"not handled\" branch in `hooks/DSC.js`, the code referenced a `line` variable that was never declared. Any unmapped category/telecommand combination therefore threw `ReferenceError: line is not defined` instead of emitting the `notifications.dsc_parser` notice.

This matches the `line is not defined` error reported in #217.

## Changes

- `hooks/DSC.js`: use the destructured `sentence` (the full raw NMEA line) in both the log message and the notification value.
- Switched the stdout `console.log` to the existing `debug('signalk-parser-nmea0183/DSC')` channel to match the rest of the module.
- `test/DSC.js`: added a regression test that feeds a routine-category DSC sentence with an unmapped telecommand and asserts it produces the `notifications.dsc_parser` delta without throwing.

This does not fix the deeper DSC parsing bugs described in #217 (Distress Relay fs=16, empty category for distress). It only addresses the reference error so unhandled cases degrade gracefully.

## Test plan

- [x] `npx mocha test/DSC.js` — all four cases pass
- [x] `npx prettier --check hooks/DSC.js test/DSC.js`
- [x] Full `npm test` — same pre-existing ZDA timestamp-ms failure on master (unrelated to this PR)