### PR TITLE
fix(VDM): place AIS Base Stations (type 4) under atons context

### DIFF
--- a/hooks/VDM.js
+++ b/hooks/VDM.js
@@ -54,10 +54,16 @@ const msgTypeToTransmitterClass = {
   21: 'ATON'
 }
 
+// AIS Base Stations (type 4) aren't vessels — they are fixed shore-based
+// stations that broadcast position + UTC time. Route them to `atons.` so
+// clients don't display them as vessels. There isn't a dedicated context in
+// the Signal K spec for base stations, and atons is consistent with how other
+// non-vessel AIS targets are handled.
 const msgTypeToPrefix = {
   1: 'vessels.',
   2: 'vessels.',
   3: 'vessels.',
+  4: 'atons.',
   5: 'vessels.',
   9: 'aircraft.',
   18: 'vessels.',

--- a/test/VDM.js
+++ b/test/VDM.js
@@ -147,6 +147,22 @@ describe('VDM', function () {
     delta.updates[0].values[2].value.should.equal(3.049090203930291)
   })
 
+  it('Base station (type 4) is placed under atons context, not vessels', () => {
+    const delta = new Parser().parse(
+      '!AIVDM,1,1,,A,403OviQuMGCqWrRO9>E6fE700@GO,0*4D\n'
+    )
+    delta.context.should.equal('atons.urn:mrn:imo:mmsi:003669702')
+    delta.updates[0].values
+      .find((pathValue) => pathValue.path === 'sensors.ais.class')
+      .value.should.equal('BASE')
+    delta.updates[0].values
+      .find((pathValue) => pathValue.path === 'navigation.position')
+      .value.longitude.should.equal(-76.35236166666667)
+    delta.updates[0].values
+      .find((pathValue) => pathValue.path === 'navigation.position')
+      .value.latitude.should.equal(36.883766666666666)
+  })
+
   it('class B position report with non-AI talker', () => {
     const delta = new Parser().parse(
       '!BSVDM,1,1,,A,B6CdCm0t3`tba35f@V9faHi7kP06,0*41\n'


### PR DESCRIPTION
## Summary

AIS Base Station reports (msg type 4) carry `sensors.ais.class = BASE` but had no entry in `msgTypeToPrefix`, so they fell through to the default `vessels.` context and clients displayed shore stations as vessels.

This PR routes type 4 to `atons.`, matching the issue reporter's expectation and consistent with how other non-vessel AIS targets are placed. The Signal K spec has no dedicated base-station context; `atons.` is the closest non-vessel fit.

## Changes

- `hooks/VDM.js`: add `4: 'atons.'` to `msgTypeToPrefix`, with a comment explaining the rationale.
- `test/VDM.js`: add a regression test using a real Type 4 sentence (MMSI `003669702`) asserting `atons.` context, `sensors.ais.class = BASE`, and decoded position.

## Test plan

- [x] `npx mocha test/VDM.js` — 17/17 pass including the new case
- [x] `npx prettier --check` clean
- [x] Full `npm test` — only the pre-existing unrelated ZDA timestamp-ms failure remains

Fixes #256