### PR TITLE
feat(VDM): decode rate-of-turn from AIS position reports (types 1/2/3)

### DIFF
--- a/hooks/VDM.js
+++ b/hooks/VDM.js
@@ -165,6 +165,27 @@ module.exports = function (input, session) {
     })
   }
 
+  // AIS rate-of-turn (ITU-R M.1371-5, msg types 1/2/3):
+  //     0 : not turning
+  //     1..126 / -1..-126 : turning right/left, ROT_deg_per_min = sign(rot) * (|rot|/4.733)^2
+  //     127 / -127 : turning right/left at >5 deg/30s, no rate available
+  //     -128 (0x80) : no turn information
+  // ggencoder exposes the raw signed byte in `data.rot`; skip it when the value
+  // doesn't carry a usable rate.
+  if (
+    typeof data.rot !== 'undefined' &&
+    data.rot !== -128 &&
+    data.rot !== 127 &&
+    data.rot !== -127
+  ) {
+    const rotDegPerMin =
+      Math.sign(data.rot) * Math.pow(Math.abs(data.rot) / 4.733, 2)
+    values.push({
+      path: 'navigation.rateOfTurn',
+      value: utils.transform(rotDegPerMin, 'deg', 'rad') / 60
+    })
+  }
+
   if (data.length) {
     values.push({
       path: 'design.length',

--- a/test/VDM.js
+++ b/test/VDM.js
@@ -94,6 +94,63 @@ describe('VDM', function () {
         return pv.path === 'navigation.speedOverGround'
       })
     )
+    // rot=-128 (no turn information) must not emit a rateOfTurn
+    should.not.exist(
+      delta.updates[0].values.find((pv) => {
+        return pv.path === 'navigation.rateOfTurn'
+      })
+    )
+  })
+
+  it('AIS rate-of-turn decoding (types 1/2/3)', () => {
+    const cases = [
+      // sentence,                                                   expectedRad (null = not emitted)
+      // Generated via ggencoder.AisEncode with known rot raw values:
+      // rot=0  -> not turning (emit 0)
+      ['!AIVDM,1,1,,A,13aEOK000j0Fpn0NDrh3Q2mp0000,0*5B', 0],
+      // rot=50  -> ~111.6 deg/min right = ~0.03247 rad/s
+      ['!AIVDM,1,1,,A,13aEOK0<Pj0Fpn0NDrh3Q2mp0000,0*37', '>0'],
+      // rot=-50 -> ~-111.6 deg/min = ~-0.03247 rad/s
+      ['!AIVDM,1,1,,A,13aEOK0kPj0Fpn0NDrh3Q2mp0000,0*60', '<0'],
+      // rot=127 -> saturated "turning right, no rate available" -> not emitted
+      ['!AIVDM,1,1,,A,13aEOK0Ohj0Fpn0NDrh3Q2mp0000,0*7C', null],
+      // rot=-127 -> saturated "turning left, no rate available" -> not emitted
+      ['!AIVDM,1,1,,A,13aEOK0P@j0Fpn0NDrh3Q2mp0000,0*4B', null],
+      // rot=-128 -> no turn information -> not emitted
+      ['!AIVDM,1,1,,A,13aEOK0P0j0Fpn0NDrh3Q2mp0000,0*3B', null]
+    ]
+    for (const [sentence, expected] of cases) {
+      const delta = new Parser().parse(sentence + '\n')
+      const rot = delta.updates[0].values.find(
+        (pv) => pv.path === 'navigation.rateOfTurn'
+      )
+      if (expected === null) {
+        should.not.exist(
+          rot,
+          `rateOfTurn should not be emitted for ${sentence}`
+        )
+      } else if (expected === 0) {
+        rot.value.should.equal(0)
+      } else if (expected === '>0') {
+        rot.value.should.be.greaterThan(0)
+      } else if (expected === '<0') {
+        rot.value.should.be.lessThan(0)
+      }
+    }
+    // Symmetry: rot=+50 and rot=-50 should have equal magnitude, opposite sign
+    const pos = new Parser()
+      .parse('!AIVDM,1,1,,A,13aEOK0<Pj0Fpn0NDrh3Q2mp0000,0*37\n')
+      .updates[0].values.find((pv) => pv.path === 'navigation.rateOfTurn').value
+    const neg = new Parser()
+      .parse('!AIVDM,1,1,,A,13aEOK0kPj0Fpn0NDrh3Q2mp0000,0*60\n')
+      .updates[0].values.find((pv) => pv.path === 'navigation.rateOfTurn').value
+    pos.should.be.closeTo(-neg, 1e-12)
+    // Sanity-check the magnitude: rot=50 -> (50/4.733)^2 deg/min -> rad/s.
+    // Tolerance is loose enough to absorb the small deg->rad constant delta
+    // between utils.transform and Math.PI/180.
+    const expectedDegPerMin = Math.pow(50 / 4.733, 2)
+    const expectedRadPerSec = (expectedDegPerMin * Math.PI) / 180 / 60
+    pos.should.be.closeTo(expectedRadPerSec, 1e-10)
   })
 
   it('AtoN converts ok', () => {


### PR DESCRIPTION
## Summary

AIS position reports (msg types 1/2/3) carry a signed 8-bit rate-of-turn field, but `hooks/VDM.js` ignored it entirely. `navigation.rateOfTurn` was never populated from AIVDM even though the Signal K spec defines the path and ggencoder already exposes the raw byte in `data.rot`.

Per ITU-R M.1371-5, the encoding is `ROT_AIS = sign(ROT) * 4.733 * sqrt(|ROT_deg_per_min|)`, with special sentinels for "no rate available" and "no turn information". This PR applies the inverse formula and emits only when the raw byte carries a real rate.

## Handling

| Raw `rot` | Meaning | Output |
|---|---|---|
| `0` | not turning | emit `0` rad/s |
| `1..126` / `-1..-126` | turning right/left | emit decoded rad/s |
| `127` / `-127` | >5 deg/30s, rate unavailable | skip (no emit) |
| `-128` | no turn information | skip (no emit) |
| `undefined` | field not present | skip |

## Changes

- `hooks/VDM.js`: decode `data.rot` after the heading block; emit `navigation.rateOfTurn` in rad/s.
- `test/VDM.js`: added a table-driven test covering zero, positive, negative, both saturated sentinels, and the "no info" sentinel, using sentences generated by `ggencoder.AisEncode` with controlled raw rot values. Added a symmetry check (rot=+50 and rot=-50 produce equal-magnitude opposite-sign rates) and a magnitude cross-check against the AIS formula. Also extended the existing "Unavailable values don't convert" test to assert rateOfTurn is not emitted for rot=-128.

## Test plan

- [x] `npx mocha test/VDM.js` — 17/17 pass
- [x] `npx prettier --check hooks/VDM.js test/VDM.js`
- [x] Full `npm test` — only the pre-existing unrelated ZDA timestamp-ms failure

Fixes #178