### PR TITLE
feat(APB): emit spec-correct `nextPoint.bearing{True,Magnetic}` alongside legacy path

### DIFF
--- a/hooks/APB.js
+++ b/hooks/APB.js
@@ -124,6 +124,14 @@ module.exports = function (input) {
             path: `navigation.courseRhumbline.bearingToDestination${bearingPositionToDestType}`,
             value: bearingPositionToDest
           },
+          // Spec path for present-position-to-destination bearing, emitted
+          // alongside the legacy `bearingToDestination*` above so existing
+          // consumers keep working. Schema reference:
+          // groups/navigation.json -> course.nextPoint.bearing{True,Magnetic}.
+          {
+            path: `navigation.courseRhumbline.nextPoint.bearing${bearingPositionToDestType}`,
+            value: bearingPositionToDest
+          },
           {
             path: 'navigation.courseRhumbline.nextPoint.ID',
             value: destinationWaypointID

--- a/test/APB.js
+++ b/test/APB.js
@@ -43,6 +43,13 @@ describe('APB', (done) => {
           x.path === 'navigation.courseRhumbline.bearingToDestinationMagnetic'
       )
       .value.should.be.closeTo(0.19198621776321237, 0.000001)
+    // Spec path for present-position-to-destination bearing (emitted alongside
+    // the legacy `bearingToDestinationMagnetic` for backwards compatibility).
+    delta.updates[0].values
+      .find(
+        (x) => x.path === 'navigation.courseRhumbline.nextPoint.bearingMagnetic'
+      )
+      .value.should.be.closeTo(0.19198621776321237, 0.000001)
     delta.updates[0].values
       .find((x) => x.path === 'navigation.courseRhumbline.nextPoint.ID')
       .value.should.equal('DEST')
@@ -59,6 +66,22 @@ describe('APB', (done) => {
         (x) => x.path === 'notifications.perpendicularPassed'
       ).value
     ).to.be.null
+  })
+
+  it('True-bearing variant emits nextPoint.bearingTrue (spec path) alongside legacy bearingToDestinationTrue', () => {
+    const delta = new Parser().parse(
+      '$GPAPB,A,A,0.10,R,N,V,V,011,T,DEST,011,T,011,T*25'
+    )
+    delta.updates[0].values
+      .find(
+        (x) => x.path === 'navigation.courseRhumbline.bearingToDestinationTrue'
+      )
+      .value.should.be.closeTo(0.19198621776321237, 0.000001)
+    delta.updates[0].values
+      .find(
+        (x) => x.path === 'navigation.courseRhumbline.nextPoint.bearingTrue'
+      )
+      .value.should.be.closeTo(0.19198621776321237, 0.000001)
   })
 
   it("Doesn't choke on an empty sentence", () => {


### PR DESCRIPTION
## Summary

The Signal K schema in `@signalk/signalk-schema` defines `navigation.courseRhumbline.nextPoint.bearing{True,Magnetic}` as the present-position-to-destination bearing. `hooks/APB.js` currently emits that value as `navigation.courseRhumbline.bearingToDestination{True,Magnetic}`, which isn't in the schema.

This PR emits the spec path **alongside** the existing one, not instead of it, so consumers on the legacy path (PyPilot, downstream Course API) keep working. Consumers can migrate at their own pace.

## Scope

Only the present-position-to-destination bearing is touched. The other `#239` items are deferred:

- `steering.autopilot.target.heading{True,Magnetic}` — actually spec-correct per the schema shipped in this repo (`groups/steering.json`). No change needed.
- `bearingOriginToDestination{True,Magnetic}` (duplicate of `bearingTrack{True,Magnetic}`) — kept for legacy reasons, same rationale as the other duplicates.
- `navigation.courseRhumbline.nextPoint.ID` — not in the schema but widely consumed; needs a separate spec discussion.

## Changes

- `hooks/APB.js`: add one emission line for `nextPoint.bearing${Type}` with a comment explaining the additive rationale and the schema reference.
- `test/APB.js`: extend the Magnetic test to assert both the legacy and spec paths carry the same value; add a new True-bearing variant test with a fresh APB sentence (`$GPAPB,A,A,0.10,R,N,V,V,011,T,DEST,011,T,011,T*25`).

## Test plan

- [x] `npx mocha test/APB.js` — 3/3 pass
- [x] `npx prettier --check hooks/APB.js test/APB.js`
- [x] Full `npm test` — only the pre-existing unrelated ZDA timestamp-ms failure

Refs #239