### PR TITLE
refactor(DSC): scope `delta` to the hook function instead of the module

### DIFF
--- a/hooks/DSC.js
+++ b/hooks/DSC.js
@@ -19,7 +19,6 @@
 
 const debug = require('debug')('signalk-parser-nmea0183/DSC')
 const utils = require('@signalk/nmea0183-utilities')
-var delta = {}
 
 function isEmpty(mixed) {
   return (
@@ -188,21 +187,20 @@ module.exports = function (input) {
       }
     })
   }
-  if (values.length > 0) {
-    //multiplexer.self();
-
-    delta = {
-      updates: [
-        {
-          source: tags.source, //this.source(input.instrument),
-          timestamp: tags.timestamp,
-          values: values
-        }
-      ],
-      context: 'vessels.urn:mrn:imo:mmsi:' + mmsi
-    }
+  if (values.length === 0) {
+    return null
   }
-  return delta
+
+  return {
+    updates: [
+      {
+        source: tags.source,
+        timestamp: tags.timestamp,
+        values: values
+      }
+    ],
+    context: 'vessels.urn:mrn:imo:mmsi:' + mmsi
+  }
 }
 
 /*

--- a/test/DSC.js
+++ b/test/DSC.js
@@ -52,4 +52,16 @@ describe('DSC', () => {
     )
     delta.context.should.equal('vessels.urn:mrn:imo:mmsi:338158137')
   })
+
+  it('Consecutive parses return independent deltas (no shared state)', () => {
+    // Guards against a previous module-scope `delta` variable that leaked
+    // across invocations. Each call must return a fresh object with its own
+    // context — not a reference to the hook's prior result.
+    const parser = new Parser()
+    const d1 = parser.parse(nmeaLinePos)
+    const d2 = parser.parse(nmeaLineDistress)
+    d1.should.not.equal(d2)
+    d1.context.should.equal('vessels.urn:mrn:imo:mmsi:338158137')
+    d2.context.should.equal('vessels.urn:mrn:imo:mmsi:338040079')
+  })
 })


### PR DESCRIPTION
## Summary

Followup to #299. The `var delta = {}` at module scope in `hooks/DSC.js` was reused across every invocation of the hook. Every successful path reassigns it before returning, but if a future change ever lands a branch where `values.length === 0` while still reaching the end of the function, the return would hand back the *previous* sentence's delta. The `empty > 3` short-circuit masks this today, but the shared state is fragile.

## Changes

- `hooks/DSC.js`: remove the module-scope `var delta`, return `null` explicitly when no values were pushed, build the delta inline in the return. Also drops the `//multiplexer.self();` stub and `//this.source(input.instrument)` comment — dead code from the pre-parser era.
- `test/DSC.js`: add a regression test that two consecutive parses produce distinct delta objects with the correct contexts.

## Test plan

- [x] `npx mocha test/DSC.js` — 5/5 pass
- [x] `npx prettier --check hooks/DSC.js test/DSC.js`
- [x] Full `npm test` — only the pre-existing unrelated ZDA timestamp-ms failure