### PR TITLE
fix(Parser): fail fast on `new Parser(null)` with a clear TypeError

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,7 +30,12 @@ class Parser {
       onPropertyValues: () => undefined
     }
   ) {
-    this.options = typeof opts === 'object' && opts !== null ? opts : {}
+    if (opts === null) {
+      throw new TypeError(
+        'Parser options must not be null; pass undefined or an options object'
+      )
+    }
+    this.options = typeof opts === 'object' ? opts : {}
     if (!Object.keys(this.options).includes('validateChecksum')) {
       this.options.validateChecksum = true
     }

--- a/test/info.js
+++ b/test/info.js
@@ -50,4 +50,8 @@ describe('Package info', () => {
     const parser = new Parser('not-an-object')
     parser.options.validateChecksum.should.equal(true)
   })
+
+  it('Throws a TypeError when the options argument is null', () => {
+    ;(() => new Parser(null)).should.throw(TypeError, /must not be null/)
+  })
 })


### PR DESCRIPTION
## Summary

`new Parser(null)` currently crashes with `TypeError: Cannot read properties of null (reading 'onPropertyValues')` from deep inside the constructor. `null` bypasses the default-parameter value (defaults only apply to `undefined`) and then hits a stale reference a few lines later.

`null` as a Parser options argument is almost always a caller bug. Silently normalising it to `{}` would hide that bug; crashing with a misleading error hides the cause. This PR validates up front and throws a `TypeError` that names the actual problem:

```
TypeError: Parser options must not be null; pass undefined or an options object
```

Non-null non-object inputs (e.g. strings) continue to be tolerated so this change stays narrowly focused on the crashing case.

## Repro (before)

```js
const Parser = require('@signalk/nmea0183-signalk')
new Parser(null)
// TypeError: Cannot read properties of null (reading 'onPropertyValues')
//     at new Parser (lib/index.js:45:10)
```

## After

```js
new Parser(null)
// TypeError: Parser options must not be null; pass undefined or an options object
//     at new Parser (lib/index.js:34:13)
```

## Test plan

- [x] Added regression test in `test/info.js`: `Throws a TypeError when the options argument is null`
- [x] Verified the new test fails on `master` (current crash is a different error) and passes with the fix
- [x] `npm test` — 268 passing
- [x] `npm run prettier:check` — clean

Split out of #304 per reviewer request to keep the coverage PR purely behavior-preserving.