### PR TITLE
chore: bump @signalk/nmea0183-utilities to ^1.0.0

### DIFF
--- a/hooks/RMC.js
+++ b/hooks/RMC.js
@@ -70,7 +70,7 @@ module.exports = function (input) {
   variation =
     parts[9].trim().length > 0 && !isNaN(parts[9]) && 'EW'.includes(parts[10])
       ? utils.transform(
-          utils.magneticVariaton(parts[9], parts[10]),
+          utils.magneticVariation(parts[9], parts[10]),
           'deg',
           'rad'
         )

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.18.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@signalk/nmea0183-utilities": "^0.12.0",
+        "@signalk/nmea0183-utilities": "^1.0.0",
         "@signalk/signalk-schema": "^1.7.1",
         "ggencoder": "^1.0.8",
         "split": "^1.0.1"
@@ -1466,10 +1466,13 @@
       }
     },
     "node_modules/@signalk/nmea0183-utilities": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@signalk/nmea0183-utilities/-/nmea0183-utilities-0.12.0.tgz",
-      "integrity": "sha512-kARrM9DN+Kj51FoiUHnUNLL97GwWF4t+O5SovaZ+BHr76iwxjBlxJ5TV8lXgvNcu3UvxPVJHP/uygeuJJWKbXA==",
-      "license": "Apache-2.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@signalk/nmea0183-utilities/-/nmea0183-utilities-1.0.0.tgz",
+      "integrity": "sha512-evbxGY2O6SNT2qDNMb/LvXnMZotk8h5e6v2J2olGllpM1gcPlKNhv39zNHoLj7jtDA2Soz4i4MEXpFwAkbb73g==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22"
+      }
     },
     "node_modules/@signalk/signalk-schema": {
       "version": "1.8.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "author": "Fabian Tollenaar <fabian@signalk.org> (http://signalk.org)",
   "license": "Apache-2.0",
   "dependencies": {
-    "@signalk/nmea0183-utilities": "^0.12.0",
+    "@signalk/nmea0183-utilities": "^1.0.0",
     "@signalk/signalk-schema": "^1.7.1",
     "ggencoder": "^1.0.8",
     "split": "^1.0.1"


### PR DESCRIPTION
Minimal JS-only update to consume [`@signalk/nmea0183-utilities@1.0.0`](https://github.com/SignalK/nmea0183-utilities/releases/tag/v1.0.0), released earlier today.

## What v1 of the utilities changed that actually bites this repo

v1 of the utilities dropped the long-standing typo alias `magneticVariaton` in favour of the canonical `magneticVariation`. That's the only v1 break that affects us — the alias is used in exactly one place, `hooks/RMC.js`. Rename it.

The other v1 breaks (strict `UnitFormat` / `Pole` type pinning, removed `integer` / `double` aliases, `zero()` integer-only, 2-digit year `YY >= 80 → 19YY` interpretation) don't bite this package's source:

- No `utils.integer` / `utils.double` call sites.
- No `utils.zero(...)` call sites with strings or non-integers.
- Every `utils.transform(...)` already passes lowercase units (`'deg'`, `'rad'`, `'knots'`, `'ms'`, `'kph'`, etc.).
- Every `utils.coordinate(...)` and `utils.magneticVariation(...)` already passes uppercase pole letters raw from the NMEA field (and the v1 utilities enforce that at runtime — malformed input now throws `unsupported pole: <value>` instead of silently returning a wrong-sign coordinate).

So a one-line source change plus the dep bump.

## Verification

- [x] `npm ci && npm test` — 424 passing
- [x] `npm run prettier:check` — clean
- [x] `hooks/RMC.js` call site verified by running the existing RMC specs (checksum/prefix/variation paths all green).

## Follow-up

A separate PR will port the source to TypeScript strict on top of this. Keeping the dep bump reviewable on its own makes that second PR strictly about the TS migration.

## Test plan for reviewers

- [x] `npm ci && npm test` on the branch
- [x] `git diff master...HEAD` fits on one screen — just `package.json`, `package-lock.json`, and one line in `hooks/RMC.js`
- [x] Grep for `magneticVariaton` in the repo to confirm no stragglers