### PR TITLE
chore: bump typescript 5.9 -> 6.0, add isolatedModules + stripInternal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "prettier": "^3.8.2",
         "rimraf": "^6.1.3",
         "tsx": "^4.21.0",
-        "typescript": "^5.9.3"
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": ">=22"
@@ -4253,9 +4253,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "prettier": "^3.8.2",
     "rimraf": "^6.1.3",
     "tsx": "^4.21.0",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "repository": {
     "type": "git",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,10 @@
     "target": "ES2022",
     "module": "commonjs",
     "moduleResolution": "node",
+    // TS 6 turned the legacy `node` (a.k.a. node10) moduleResolution into a
+    // hard deprecation. Silence that so the package can stay on `node` for
+    // now; migrating to `node16` / `bundler` is a separate audit.
+    "ignoreDeprecations": "6.0",
     "lib": ["ES2022"],
 
     "strict": true,
@@ -12,15 +16,22 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noUncheckedIndexedAccess": true,
+    // Each file must transpile independently (tsx / esbuild / bundler
+    // assumptions). Surfaces edge cases before they break a downstream.
+    "isolatedModules": true,
 
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
+    // TS 6 tightened the default @types scan: mocha's describe / it globals
+    // no longer leak in unless the test runner is listed here explicitly.
+    "types": ["node", "mocha"],
 
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
+    "stripInternal": true,
     "outDir": "dist",
     "rootDir": "."
   },


### PR DESCRIPTION
## Summary

Aligns this package with the rest of the SignalK plugin family on typescript `^6.0.3` and a uniform strict compiler-options set.

tsconfig additions:
- `ignoreDeprecations: "6.0"` — silences the TS 6 hard deprecation of the legacy `node` moduleResolution. Migrating to `node16` / `bundler` is a separate audit.
- `types: ["node", "mocha"]` — TS 6 tightened the default @types scan; mocha's `describe` / `it` globals no longer leak in automatically.
- `isolatedModules: true` — each file must transpile independently (tsx / esbuild / bundler assumption).
- `stripInternal: true` — omits `@internal`-tagged declarations from the shipped `.d.ts`.

Supersedes dependabot #312 (plain version bump without the tsconfig knobs, fails CI).

## Test plan

- [x] npm run typecheck clean
- [x] npm run build clean
- [x] npm test 424 passing
- [x] npm run prettier:check clean
- [ ] CI green on Node 22 + Node 24