### PR TITLE
fix(hooks): preserve NMEA null-field semantics (IEC 61162-1 §7.2.3.4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.19.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@signalk/nmea0183-utilities": "^1.0.0",
+        "@signalk/nmea0183-utilities": "^1.1.0",
         "@signalk/signalk-schema": "^1.7.1",
         "ggencoder": "^1.0.8",
         "split": "^1.0.1"
@@ -1479,9 +1479,9 @@
       "license": "MIT"
     },
     "node_modules/@signalk/nmea0183-utilities": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@signalk/nmea0183-utilities/-/nmea0183-utilities-1.0.0.tgz",
-      "integrity": "sha512-evbxGY2O6SNT2qDNMb/LvXnMZotk8h5e6v2J2olGllpM1gcPlKNhv39zNHoLj7jtDA2Soz4i4MEXpFwAkbb73g==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@signalk/nmea0183-utilities/-/nmea0183-utilities-1.1.0.tgz",
+      "integrity": "sha512-akq83MYi/GHRERu+dk3faSrG1I3Av6mqZklObqHkCN1oQddl7ReoyoNrGXI8gglcKU5Nzg7QtKR815W7YfYVqA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "author": "Fabian Tollenaar <fabian@signalk.org> (http://signalk.org)",
   "license": "Apache-2.0",
   "dependencies": {
-    "@signalk/nmea0183-utilities": "^1.0.0",
+    "@signalk/nmea0183-utilities": "^1.1.0",
     "@signalk/signalk-schema": "^1.7.1",
     "ggencoder": "^1.0.8",
     "split": "^1.0.1"

--- a/src/hooks/APB.ts
+++ b/src/hooks/APB.ts
@@ -60,7 +60,6 @@ const APB: HookFn = function (
   }
 
   if (parts[0]!.trim().toUpperCase() === 'V') {
-    // Don't parse this sentence as it's void.
     throw new Error(
       "Not parsing sentence for it's void (LORAN-C blink/SNR warning)"
     )
@@ -72,7 +71,8 @@ const APB: HookFn = function (
     )
   }
 
-  // XTE
+  // XTE: magnitude + L/R direction letter. Both are guarded as
+  // required above, so xte is always a real number here.
   const direction = parts[3]!.trim().toUpperCase() === 'L' ? 1 : -1
   const xte =
     direction *
@@ -82,25 +82,23 @@ const APB: HookFn = function (
       'm'
     )
 
-  // WP arrival status
   const arrivalCircleEntered = parts[5]!.trim().toUpperCase() === 'A'
   const perpendicularPassed = parts[6]!.trim().toUpperCase() === 'A'
 
-  // Bearing, origin to destination
-  const bearingOriginToDest = utils.transform(parts[7]!, 'deg', 'rad')
+  // Bearings + heading-to-steer are each magnitude + unit letter
+  // triples. Magnitudes are null-preserving (IEC 61162-1 §7.2.3.4);
+  // the unit letter picks which axis the value lives on.
+  const bearingOriginToDest = utils.transformOrNull(parts[7]!, 'deg', 'rad')
   const bearingOriginToDestType =
     parts[8]!.trim().toUpperCase() === 'M' ? 'Magnetic' : 'True'
 
-  // Destination Waypoint ID
   const destinationWaypointID = parts[9]!.trim()
 
-  // Bearing, position to destination
-  const bearingPositionToDest = utils.transform(parts[10]!, 'deg', 'rad')
+  const bearingPositionToDest = utils.transformOrNull(parts[10]!, 'deg', 'rad')
   const bearingPositionToDestType =
     parts[11]!.trim().toUpperCase() === 'M' ? 'Magnetic' : 'True'
 
-  // Heading to steer
-  const headingToSteer = utils.transform(parts[12]!, 'deg', 'rad')
+  const headingToSteer = utils.transformOrNull(parts[12]!, 'deg', 'rad')
   const headingToSteerType =
     parts[13]!.trim().toUpperCase() === 'M' ? 'Magnetic' : 'True'
 

--- a/src/hooks/BOD.ts
+++ b/src/hooks/BOD.ts
@@ -40,22 +40,27 @@ const BOD: HookFn = function (
 
   debug(`[BODHook] decoding sentence ${id} => ${sentence}`)
 
+  // Unit letters + destination waypoint ID are required; without them
+  // the bearing pair can't be assigned to the correct axis and the
+  // sentence carries no actionable routing information. Bearing
+  // magnitudes are null-preserving per IEC 61162-1 §7.2.3.4.
   if (
-    upper(parts[0]!) === '' ||
     upper(parts[1]!) === '' ||
-    upper(parts[2]!) === '' ||
     upper(parts[3]!) === '' ||
     upper(parts[4]!) === ''
   ) {
     return null
   }
 
-  const bearingOriginToDestination: Record<string, number> = {}
-
+  const bearingOriginToDestination: Record<string, number | null> = {
+    True: null,
+    Magnetic: null
+  }
   bearingOriginToDestination[upper(parts[1]!) === 'T' ? 'True' : 'Magnetic'] =
-    utils.transform(parts[0]!, 'deg', 'rad')
+    utils.transformOrNull(parts[0]!, 'deg', 'rad')
   bearingOriginToDestination[upper(parts[3]!) === 'T' ? 'True' : 'Magnetic'] =
-    utils.transform(parts[2]!, 'deg', 'rad')
+    utils.transformOrNull(parts[2]!, 'deg', 'rad')
+
   const destinationWaypointID = parts[4]!.trim()
   const originWaypointID = parts[5]!.trim()
 
@@ -67,11 +72,11 @@ const BOD: HookFn = function (
         values: [
           {
             path: 'navigation.courseRhumbline.bearingTrackTrue',
-            value: bearingOriginToDestination['True'] ?? null
+            value: bearingOriginToDestination['True']
           },
           {
             path: 'navigation.courseRhumbline.bearingTrackMagnetic',
-            value: bearingOriginToDestination['Magnetic'] ?? null
+            value: bearingOriginToDestination['Magnetic']
           },
           {
             path: 'navigation.courseRhumbline.nextPoint.ID',

--- a/src/hooks/BOD.ts
+++ b/src/hooks/BOD.ts
@@ -72,11 +72,11 @@ const BOD: HookFn = function (
         values: [
           {
             path: 'navigation.courseRhumbline.bearingTrackTrue',
-            value: bearingOriginToDestination['True']
+            value: bearingOriginToDestination['True'] ?? null
           },
           {
             path: 'navigation.courseRhumbline.bearingTrackMagnetic',
-            value: bearingOriginToDestination['Magnetic']
+            value: bearingOriginToDestination['Magnetic'] ?? null
           },
           {
             path: 'navigation.courseRhumbline.nextPoint.ID',

--- a/src/hooks/BWC.ts
+++ b/src/hooks/BWC.ts
@@ -62,51 +62,48 @@ const BWC: HookFn = function (
     result.updates[0]!.timestamp = utils.timestamp(parts[0]!)
   }
 
-  if (
-    parts[1]! !== '' &&
-    parts[2]! !== '' &&
-    parts[3]! !== '' &&
-    parts[4]! !== ''
-  ) {
-    const latitude = coord(parts[1]!, parts[2]!)
-    const longitude = coord(parts[3]!, parts[4]!)
-    values.push({
-      path: 'navigation.courseGreatCircle.nextPoint.position',
-      value: {
-        longitude,
-        latitude
-      }
-    })
-  } else {
-    values.push({
-      path: 'navigation.courseGreatCircle.nextPoint.position',
-      value: null
-    })
-  }
+  // All four of parts[1..4] (lat/NS, lon/EW) are required to emit a
+  // position — `coord('', pole)` returns 0, which would round-trip to
+  // `{ latitude: 0, longitude: 0 }` if we only null-checked `coord`'s
+  // return.
+  const havePosition =
+    parts[1]! !== '' && parts[2]! !== '' && parts[3]! !== '' && parts[4]! !== ''
+  values.push({
+    path: 'navigation.courseGreatCircle.nextPoint.position',
+    value: havePosition
+      ? {
+          latitude: coord(parts[1]!, parts[2]!),
+          longitude: coord(parts[3]!, parts[4]!)
+        }
+      : null
+  })
 
-  if (parts[9]! !== '' && parts[10]! !== '') {
-    const distance = utils.transform(
-      parts[9]!,
-      upper(parts[10]!) === 'N' ? 'nm' : 'km',
-      'm'
-    )
+  const distanceUnit = upper(parts[10]!) === 'N' ? 'nm' : 'km'
+  const distance = utils.transformOrNull(parts[9]!, distanceUnit, 'm')
+  if (distance !== null) {
     values.push({
       path: 'navigation.courseGreatCircle.nextPoint.distance',
       value: distance
     })
   }
 
-  if (parts[6]! === 'T' && parts[5]! !== '') {
-    values.push({
-      path: 'navigation.courseGreatCircle.bearingTrackTrue',
-      value: utils.transform(parts[5]!, 'deg', 'rad')
-    })
+  if (parts[6]! === 'T') {
+    const bearing = utils.transformOrNull(parts[5]!, 'deg', 'rad')
+    if (bearing !== null) {
+      values.push({
+        path: 'navigation.courseGreatCircle.bearingTrackTrue',
+        value: bearing
+      })
+    }
   }
-  if (parts[8]! === 'M' && parts[7]! !== '') {
-    values.push({
-      path: 'navigation.courseGreatCircle.bearingTrackMagnetic',
-      value: utils.transform(parts[7]!, 'deg', 'rad')
-    })
+  if (parts[8]! === 'M') {
+    const bearing = utils.transformOrNull(parts[7]!, 'deg', 'rad')
+    if (bearing !== null) {
+      values.push({
+        path: 'navigation.courseGreatCircle.bearingTrackMagnetic',
+        value: bearing
+      })
+    }
   }
 
   return result

--- a/src/hooks/BWR.ts
+++ b/src/hooks/BWR.ts
@@ -81,11 +81,11 @@ const BWR: HookFn = function (
         values: [
           {
             path: 'navigation.courseRhumbline.bearingTrackTrue',
-            value: bearingToWaypoint['True']
+            value: bearingToWaypoint['True'] ?? null
           },
           {
             path: 'navigation.courseRhumbline.bearingTrackMagnetic',
-            value: bearingToWaypoint['Magnetic']
+            value: bearingToWaypoint['Magnetic'] ?? null
           },
           {
             path: 'navigation.courseRhumbline.nextPoint.distance',

--- a/src/hooks/BWR.ts
+++ b/src/hooks/BWR.ts
@@ -23,14 +23,6 @@ const debug = Debug('signalk-parser-nmea0183/BWR')
  * $GPBWR,225444,4917.24,N,12309.57,W,051.9,T,031.6,M,001.3,N,004*38
  *
  * Bearing and distance to waypoint - rhumb line
- *
- * 0)     225444        UTC time of fix 22:54:44
- * 1,2)   4917.24,N     Latitude of waypoint
- * 3,4)   12309.57,W    Longitude of waypoint
- * 5,6)   051.9,T       Bearing to waypoint, degrees true
- * 7,8)   031.6,M       Bearing to waypoint, degrees magnetic
- * 9,10)  001.3,N       Distance to waypoint, Nautical miles
- * 11)    004           Waypoint ID
  **/
 
 const BWR: HookFn = function (
@@ -42,36 +34,43 @@ const BWR: HookFn = function (
 
   debug(`[BWRHook] decoding sentence ${id} => ${sentence}`)
 
-  let timestamp
-  let position
-  let distance
-  const bearingToWaypoint: Record<string, number> = {}
+  const havePosition =
+    upper(parts[0]!) !== '' &&
+    upper(parts[1]!) !== '' &&
+    upper(parts[2]!) !== '' &&
+    upper(parts[3]!) !== '' &&
+    upper(parts[4]!) !== ''
 
-  if (
-    upper(parts[0]!) === '' ||
-    upper(parts[1]!) === '' ||
-    upper(parts[2]!) === '' ||
-    upper(parts[3]!) === '' ||
-    upper(parts[4]!) === ''
-  ) {
-    timestamp = tags.timestamp
-    position = null
-    distance = null
-  } else {
-    timestamp = utils.timestamp(parts[0]!)
-    position = {
-      latitude: coord(parts[1]!, parts[2]!),
-      longitude: coord(parts[3]!, parts[4]!)
-    }
-    distance = utils.transform(
-      parts[9]!,
-      upper(parts[10]!) === 'N' ? 'nm' : 'km',
-      'm'
+  const timestamp = havePosition ? utils.timestamp(parts[0]!) : tags.timestamp
+  const position = havePosition
+    ? {
+        latitude: coord(parts[1]!, parts[2]!),
+        longitude: coord(parts[3]!, parts[4]!)
+      }
+    : null
+
+  const distanceUnit = upper(parts[10]!) === 'N' ? 'nm' : 'km'
+  const distance = havePosition
+    ? utils.transformOrNull(parts[9]!, distanceUnit, 'm')
+    : null
+
+  const bearingToWaypoint: Record<string, number | null> = {
+    True: null,
+    Magnetic: null
+  }
+  if (havePosition) {
+    const firstAxis = upper(parts[6]!) === 'T' ? 'True' : 'Magnetic'
+    const secondAxis = upper(parts[8]!) === 'T' ? 'True' : 'Magnetic'
+    bearingToWaypoint[firstAxis] = utils.transformOrNull(
+      parts[5]!,
+      'deg',
+      'rad'
     )
-    bearingToWaypoint[upper(parts[6]!) === 'T' ? 'True' : 'Magnetic'] =
-      utils.transform(parts[5]!, 'deg', 'rad')
-    bearingToWaypoint[upper(parts[8]!) === 'T' ? 'True' : 'Magnetic'] =
-      utils.transform(parts[7]!, 'deg', 'rad')
+    bearingToWaypoint[secondAxis] = utils.transformOrNull(
+      parts[7]!,
+      'deg',
+      'rad'
+    )
   }
 
   return {
@@ -82,11 +81,11 @@ const BWR: HookFn = function (
         values: [
           {
             path: 'navigation.courseRhumbline.bearingTrackTrue',
-            value: bearingToWaypoint['True'] ?? null
+            value: bearingToWaypoint['True']
           },
           {
             path: 'navigation.courseRhumbline.bearingTrackMagnetic',
-            value: bearingToWaypoint['Magnetic'] ?? null
+            value: bearingToWaypoint['Magnetic']
           },
           {
             path: 'navigation.courseRhumbline.nextPoint.distance',

--- a/src/hooks/DBK.ts
+++ b/src/hooks/DBK.ts
@@ -46,7 +46,7 @@ const DBK: HookFn = function (
         values: [
           {
             path: 'environment.depth.belowKeel',
-            value: parts[2]!.length > 0 ? utils.float(parts[2]!) : null
+            value: utils.floatOrNull(parts[2]!)
           }
         ]
       }

--- a/src/hooks/DBS.ts
+++ b/src/hooks/DBS.ts
@@ -46,7 +46,7 @@ const DBS: HookFn = function (
         values: [
           {
             path: 'environment.depth.belowSurface',
-            value: parts[2]!.length > 0 ? utils.float(parts[2]!) : null
+            value: utils.floatOrNull(parts[2]!)
           }
         ]
       }

--- a/src/hooks/DBT.ts
+++ b/src/hooks/DBT.ts
@@ -16,6 +16,10 @@
 
 import * as utils from '@signalk/nmea0183-utilities'
 import type { Delta, HookFn, ParserInput, ParserSession } from '../types'
+
+// NIST ft->m (exact). `utils.transform('ft','m')` uses RATIOS.METER_IN_FEET
+// (3.2808, truncated), which drifts ~0.003 %. Depths get reported to
+// cm precision so the exact ratio matters.
 const FEET_TO_METERS = 0.3048
 
 /*
@@ -35,26 +39,22 @@ Field Number:
 6. Checksum
 */
 
+// Prefer meters when present; fall back to feet via transformOrNull so
+// an empty sentence surfaces `null` (IEC 61162-1 §7.2.3.4) instead of
+// silent 0.
+
 const DBT: HookFn = function (
   input: ParserInput,
   _session: ParserSession
 ): Delta | null {
   const { parts, tags } = input
 
-  const rawMeters = parts[2]
-  let meterValue: number | null
-  if (hasNoValue(rawMeters)) {
-    const feetValue = parts[0]
-    if (hasNoValue(feetValue)) {
-      meterValue = null
-    } else {
-      meterValue = utils.float(feetValue) * FEET_TO_METERS
-    }
-  } else {
-    meterValue = utils.float(rawMeters)
-  }
+  const meters = utils.floatOrNull(parts[2]!)
+  const feet = utils.floatOrNull(parts[0]!)
+  const meterValue =
+    meters !== null ? meters : feet !== null ? feet * FEET_TO_METERS : null
 
-  const delta = {
+  return {
     updates: [
       {
         source: tags.source,
@@ -68,11 +68,6 @@ const DBT: HookFn = function (
       }
     ]
   }
-
-  return delta
 }
-
-const hasNoValue = (value: unknown): boolean =>
-  typeof value !== 'string' || value.trim() === ''
 
 export default DBT

--- a/src/hooks/DPT.ts
+++ b/src/hooks/DPT.ts
@@ -15,7 +15,13 @@
  */
 
 import * as utils from '@signalk/nmea0183-utilities'
-import type { Delta, HookFn, ParserInput, ParserSession } from '../types'
+import type {
+  Delta,
+  DeltaValue,
+  HookFn,
+  ParserInput,
+  ParserSession
+} from '../types'
 /*
 === DPT - Depth of water ===
 ------------------------------------------------------------------------------
@@ -38,7 +44,7 @@ const DPT: HookFn = function (
   const depth = utils.floatOrNull(parts[0]!)
   const offset = utils.floatOrNull(parts[1]!)
 
-  const values: Array<{ path: string; value: unknown }> = [
+  const values: DeltaValue[] = [
     { path: 'environment.depth.belowTransducer', value: depth }
   ]
 

--- a/src/hooks/DPT.ts
+++ b/src/hooks/DPT.ts
@@ -35,50 +35,49 @@ const DPT: HookFn = function (
 ): Delta | null {
   const { parts, tags } = input
 
-  var depth = parts[0]!.trim() == '' ? null : utils.float(parts[0]!)
+  const depth = utils.floatOrNull(parts[0]!)
+  const offset = utils.floatOrNull(parts[1]!)
 
-  const delta = {
-    updates: [
-      {
-        source: tags.source,
-        timestamp: tags.timestamp,
-        values: [
-          {
-            path: 'environment.depth.belowTransducer',
-            value: depth
-          }
-        ]
-      }
-    ]
-  }
+  const values: Array<{ path: string; value: unknown }> = [
+    { path: 'environment.depth.belowTransducer', value: depth }
+  ]
 
-  var offset = utils.float(parts[1]!)
-
-  if (offset > 0) {
-    delta.updates[0]!.values.push({
+  // NMEA defines the offset sign: positive = transducer-to-waterline
+  // distance, negative = transducer-to-keel distance. A missing or
+  // zero offset carries no additional information.
+  if (offset !== null && offset > 0) {
+    values.push({
       path: 'environment.depth.surfaceToTransducer',
       value: offset
     })
     if (depth !== null) {
-      delta.updates[0]!.values.push({
+      values.push({
         path: 'environment.depth.belowSurface',
         value: depth + offset
       })
     }
-  } else if (offset < 0) {
-    delta.updates[0]!.values.push({
+  } else if (offset !== null && offset < 0) {
+    values.push({
       path: 'environment.depth.transducerToKeel',
-      value: offset * -1
+      value: -offset
     })
     if (depth !== null) {
-      delta.updates[0]!.values.push({
+      values.push({
         path: 'environment.depth.belowKeel',
         value: depth + offset
       })
     }
   }
 
-  return delta
+  return {
+    updates: [
+      {
+        source: tags.source,
+        timestamp: tags.timestamp,
+        values
+      }
+    ]
+  }
 }
 
 export default DPT

--- a/src/hooks/DSC.ts
+++ b/src/hooks/DSC.ts
@@ -15,7 +15,13 @@
  * limitations under the License.
  */
 
-import type { Delta, HookFn, ParserInput, ParserSession } from '../types'
+import type {
+  Delta,
+  DeltaValue,
+  HookFn,
+  ParserInput,
+  ParserSession
+} from '../types'
 import Debug from 'debug'
 const debug = Debug('signalk-parser-nmea0183/DSC')
 function parsePosition(line: string): { longitude: number; latitude: number } {
@@ -60,7 +66,7 @@ const DSC: HookFn = function (
   _session: ParserSession
 ): Delta | null {
   const { sentence, parts, tags } = input
-  var values: Array<{ path: string; value: unknown }> = []
+  var values: DeltaValue[] = []
 
   // DSC drives every branch off category (parts[2]) and nature/
   // telecommand (parts[3]). Without both, there's no decision to make

--- a/src/hooks/DSC.ts
+++ b/src/hooks/DSC.ts
@@ -18,10 +18,6 @@
 import type { Delta, HookFn, ParserInput, ParserSession } from '../types'
 import Debug from 'debug'
 const debug = Debug('signalk-parser-nmea0183/DSC')
-function isEmpty(mixed: unknown): boolean {
-  return typeof mixed !== 'string' || mixed.trim() === ''
-}
-
 function parsePosition(line: string): { longitude: number; latitude: number } {
   /*
    * Position Format:
@@ -66,14 +62,20 @@ const DSC: HookFn = function (
   const { sentence, parts, tags } = input
   var values: Array<{ path: string; value: unknown }> = []
 
-  const empty = parts.reduce((e, val) => {
-    if (isEmpty(val)) {
-      ++e
-    }
-    return e
-  }, 0)
-
-  if (empty > 3) {
+  // DSC drives every branch off category (parts[2]) and nature/
+  // telecommand (parts[3]). Without both, there's no decision to make
+  // and the sentence is noise. The previous `empty > 3` count-gate
+  // dropped valid distress messages where several trailing fields
+  // (time, address, service command) were legitimately empty — see
+  // SignalK/nmea0183-signalk#192.
+  if (
+    typeof parts[1] !== 'string' ||
+    parts[1].trim() === '' ||
+    typeof parts[2] !== 'string' ||
+    parts[2].trim() === '' ||
+    typeof parts[3] !== 'string' ||
+    parts[3].trim() === ''
+  ) {
     return null
   }
 

--- a/src/hooks/DSC.ts
+++ b/src/hooks/DSC.ts
@@ -68,19 +68,18 @@ const DSC: HookFn = function (
   const { sentence, parts, tags } = input
   var values: DeltaValue[] = []
 
-  // DSC drives every branch off category (parts[2]) and nature/
-  // telecommand (parts[3]). Without both, there's no decision to make
-  // and the sentence is noise. The previous `empty > 3` count-gate
-  // dropped valid distress messages where several trailing fields
-  // (time, address, service command) were legitimately empty — see
-  // SignalK/nmea0183-signalk#192.
+  // Only the format specifier (parts[0]) and the sender MMSI (parts[1])
+  // are universally required. The DSC Category (parts[2]) is left null
+  // by the standard whenever the Format Specifier is Distress (FS=12) —
+  // see SignalK/nmea0183-signalk#217. Gating on parts[2] here would
+  // silently drop every Distress Alert that follows the spec, which
+  // is strictly worse than the pre-#192 behaviour of falling through
+  // to the "unhandled" notification.
   if (
+    typeof parts[0] !== 'string' ||
+    parts[0].trim() === '' ||
     typeof parts[1] !== 'string' ||
-    parts[1].trim() === '' ||
-    typeof parts[2] !== 'string' ||
-    parts[2].trim() === '' ||
-    typeof parts[3] !== 'string' ||
-    parts[3].trim() === ''
+    parts[1].trim() === ''
   ) {
     return null
   }

--- a/src/hooks/GGA.ts
+++ b/src/hooks/GGA.ts
@@ -56,9 +56,12 @@ Field Number:
 14. Checksum
 */
 
-function isEmpty(mixed: unknown): boolean {
-  return typeof mixed !== 'string' || mixed.trim() === ''
-}
+// IEC 61162-1 §7.2.3.4: a null field (",,") signals "sensor working,
+// value not available", so every *optional* field is emitted per-field
+// with `null` when absent. Sentence-level short-circuiting only kicks
+// in when there is literally no usable output at all (no position and
+// no quality indicator) — otherwise a receiver reporting e.g. only
+// position and no altitude would have been dropped entirely.
 
 const GGA: HookFn = function (
   input: ParserInput,
@@ -66,20 +69,13 @@ const GGA: HookFn = function (
 ): Delta | null {
   const { parts, tags } = input
 
-  const empty = parts.reduce((e, val) => {
-    if (isEmpty(val)) {
-      ++e
-    }
-    return e
-  }, 0)
-
-  if (empty > 4) {
-    return null
-  }
-
   const time =
-    parts[0]!.indexOf('.') === -1 ? parts[0]! : parts[0]!.split('.')[0]
-  const timestamp = utils.timestamp(time)
+    parts[0] && parts[0].length > 0
+      ? parts[0].indexOf('.') === -1
+        ? parts[0]
+        : parts[0].split('.')[0]!
+      : ''
+  const timestamp = time ? utils.timestamp(time) : tags.timestamp
 
   const quality = [
     'no GPS',
@@ -96,20 +92,28 @@ const GGA: HookFn = function (
 
   const latitude = coord(parts[1]!, parts[2]!)
   const longitude = coord(parts[3]!, parts[4]!)
-  let position = null
-
-  if (
+  const position =
     latitude !== null &&
     longitude !== null &&
     utils.isValidPosition(latitude, longitude)
-  ) {
-    position = {
-      latitude: latitude,
-      longitude: longitude
-    }
+      ? { latitude, longitude }
+      : null
+
+  const qualityIdx = utils.intOrNull(parts[5]!)
+  const methodQuality =
+    qualityIdx !== null && qualityIdx >= 0 && qualityIdx < quality.length
+      ? quality[qualityIdx]!
+      : null
+
+  // If neither position nor any quality signal is available the sentence
+  // carries no useful data. Returning null matches the historical
+  // "doesn't choke on empty sentence" test and keeps the output stream
+  // free of all-null deltas.
+  if (position === null && methodQuality === null) {
+    return null
   }
 
-  const delta = {
+  return {
     updates: [
       {
         source: tags.source,
@@ -121,44 +125,36 @@ const GGA: HookFn = function (
           },
           {
             path: 'navigation.gnss.methodQuality',
-            value: quality[utils.int(parts[5]!)]
+            value: methodQuality
           },
-
           {
             path: 'navigation.gnss.satellites',
-            value: utils.int(parts[6]!)
+            value: utils.intOrNull(parts[6]!)
           },
-
           {
             path: 'navigation.gnss.antennaAltitude',
-            value: utils.float(parts[8]!)
+            value: utils.floatOrNull(parts[8]!)
           },
-
           {
             path: 'navigation.gnss.horizontalDilution',
-            value: utils.float(parts[7]!)
+            value: utils.floatOrNull(parts[7]!)
           },
-
           {
             path: 'navigation.gnss.geoidalSeparation',
-            value: utils.float(parts[10]!)
+            value: utils.floatOrNull(parts[10]!)
           },
-
           {
             path: 'navigation.gnss.differentialAge',
-            value: utils.float(parts[12]!)
+            value: utils.floatOrNull(parts[12]!)
           },
-
           {
             path: 'navigation.gnss.differentialReference',
-            value: Number(parts[13]!)
+            value: utils.intOrNull(parts[13]!)
           }
         ]
       }
     ]
   }
-
-  return delta
 }
 
 export default GGA

--- a/src/hooks/GLL.ts
+++ b/src/hooks/GLL.ts
@@ -34,9 +34,15 @@ Field Number:
 6. FAA mode indicator (NMEA 2.3 and later)
 */
 
-function isEmpty(mixed: unknown): boolean {
-  return typeof mixed !== 'string' || mixed.trim() === ''
-}
+// IEC 61162-1 §7.2.3.4: null fields are a per-field marker, not a
+// sentence-level reject signal. A GLL sentence with status=A but an
+// empty time field (seen in the wild from some GPS receivers that
+// lose the clock fix but keep position) used to be dropped entirely
+// — even though the position itself is valid. Now only `status=V`
+// (explicit data-invalid) or an unparseable position drops the
+// sentence; otherwise we emit `navigation.position` (possibly null)
+// and fall back to the tag timestamp when the NMEA time field is
+// missing.
 
 const GLL: HookFn = function (
   input: ParserInput,
@@ -44,39 +50,41 @@ const GLL: HookFn = function (
 ): Delta | null {
   const { parts, tags } = input
 
-  let valid = parts.reduce((v, part) => {
-    v = !isEmpty(part)
-    return v
-  }, true)
-
-  if (typeof parts[5]! === 'string' && parts[5]!.toLowerCase() === 'v') {
-    valid = false
-  }
-
-  if (!valid) {
+  if (typeof parts[5] === 'string' && parts[5].toLowerCase() === 'v') {
     return null
   }
 
+  const rawTime = parts[4]
   const time =
-    parts[4]!.indexOf('.') === -1 ? parts[4]! : parts[4]!.split('.')[0]
-  const timestamp = utils.timestamp(time)
+    rawTime && rawTime.length > 0
+      ? rawTime.indexOf('.') === -1
+        ? rawTime
+        : rawTime.split('.')[0]!
+      : ''
+  const timestamp = time ? utils.timestamp(time) : tags.timestamp
 
   const latitude = coord(parts[0]!, parts[1]!)
   const longitude = coord(parts[2]!, parts[3]!)
-  let position = null
 
-  if (
+  // An entirely empty GLL (no position letters, no pole letters) is
+  // noise, not a "sensor working, no data" marker. `coord` returns
+  // `null` only when the pole field is missing or invalid — which is
+  // the shape of a fully-empty frame. A position that parses numerically
+  // but falls out of range (malformed bytes in the field) stays a delta
+  // with `value: null`, preserving the existing "invalid lat/lng"
+  // behaviour.
+  if (latitude === null && longitude === null) {
+    return null
+  }
+
+  const position =
     latitude !== null &&
     longitude !== null &&
     utils.isValidPosition(latitude, longitude)
-  ) {
-    position = {
-      latitude: latitude,
-      longitude: longitude
-    }
-  }
+      ? { latitude, longitude }
+      : null
 
-  const delta = {
+  return {
     updates: [
       {
         source: tags.source,
@@ -90,8 +98,6 @@ const GLL: HookFn = function (
       }
     ]
   }
-
-  return delta
 }
 
 export default GLL

--- a/src/hooks/GNS.ts
+++ b/src/hooks/GNS.ts
@@ -31,40 +31,16 @@ Field Number:
 2. N or S (North or South)
 3. Longitude, dd is minutes, mm.mm is minutes
 4. E or W (East or West)
-5. Mode indicator (non-null) - Variable character field with one character for each supported constellation:
-    * First character is for GPS
-    * Second character is for GLONASS
-    * Third character is Galileo
-    * Fourth character is for BeiDou
-    * Fifth character is for QZSS
-    * Subsequent characters will be added for new constellations
-   Each character will be one of the following
-     - N = No fix. Satellite system not used in position fix, or fix not valid
-     - A = Autonomous. Satellite system used in non-differential mode in position fix
-     - D = Differential (including all OmniSTAR services). Satellite system used in differential mode in position fix
-     - P = Precise. Satellite system used in precision mode. Precision mode is defined as: no deliberate degradation (such as Selective Availability) and higher resolution code (P-code) is used to compute position fix
-     - R = Real-Time Kinematic. Satellite system used in RTK mode with fixed integers
-     - F = Float RTK. Satellite system used in real-time kinematic mode with floating integers
-     - E = Estimated (dead reckoning) mode
-     - M = Manual Input mode
-     - S = Simulator mode
+5. Mode indicator (non-null)
 6. Total number of satellites in use, 00-99
-7. Horizontal Dilution of Precision (HDOP), calculated using all the satellites (GPS, GLONASS, and any future satellites) and used in computing the solution reported in each GNS sentence
+7. Horizontal Dilution of Precision (HDOP)
 8. Antenna altitude, meters, re:mean-sea-level (geoid)
-9. Goeidal separation meters - The difference between the earth ellipsoid surface and mean-sea-level (geoid) surface defined by the reference datum used in the position solution
-10. Age of differential data - Null if talker ID is GN, additional GNS messages follow with Age of differential data
-11. Differential reference station ID, 0000-4095 - Null if Talker ID is GN, Additional GNS messages follow with Reference station ID
-12. Navigational status (added when the IEC61162-1:2010/NMEA 0183 V4.10 option is selected in the NMEA I/O configuration):
-     - S = Safe
-     - C = Caution
-     - U = Unsafe
-     - V = Not valid for navigation
+9. Goeidal separation meters
+10. Age of differential data
+11. Differential reference station ID, 0000-4095
+12. Navigational status
 13. Checksum
 */
-
-function isEmpty(mixed: unknown): boolean {
-  return typeof mixed !== 'string' || mixed.trim() === ''
-}
 
 const MODES: Record<string, string> = {
   A: 'Autonomous',
@@ -90,103 +66,88 @@ function indicator(chars: string[]): Record<string, string | undefined> {
   }, {})
 }
 
+const STATUS: Record<string, string> = {
+  S: 'Safe',
+  C: 'Caution',
+  U: 'Unsafe',
+  V: 'Not Valid'
+}
+
+// IEC 61162-1 §7.2.3.4: every optional field surfaces as `null` when
+// missing. Short-circuit only when neither position nor mode indicator
+// can be parsed (same logic as GGA).
+
 const GNS: HookFn = function (
   input: ParserInput,
   _session: ParserSession
 ): Delta | null {
   const { parts, tags } = input
 
-  const empty = parts.reduce((e, val) => {
-    if (isEmpty(val)) {
-      ++e
-    }
-    return e
-  }, 0)
-
-  if (empty > 4) {
-    return null
-  }
-
   const time =
-    parts[0]!.indexOf('.') === -1 ? parts[0]! : parts[0]!.split('.')[0]
-  const timestamp = utils.timestamp(time)
-
-  const STATUS: Record<string, string> = {
-    S: 'Safe',
-    C: 'Caution',
-    U: 'Unsafe',
-    V: 'Not Valid'
-  }
+    parts[0] && parts[0].length > 0
+      ? parts[0].indexOf('.') === -1
+        ? parts[0]
+        : parts[0].split('.')[0]!
+      : ''
+  const timestamp = time ? utils.timestamp(time) : tags.timestamp
 
   const latitude = coord(parts[1]!, parts[2]!)
   const longitude = coord(parts[3]!, parts[4]!)
-  let position = null
-
-  if (
+  const position =
     latitude !== null &&
     longitude !== null &&
     utils.isValidPosition(latitude, longitude)
-  ) {
-    position = {
-      latitude: latitude,
-      longitude: longitude
-    }
+      ? { latitude, longitude }
+      : null
+
+  const modeField = parts[5] ?? ''
+  const methodQuality =
+    modeField.length > 0 ? indicator(modeField.split('')) : null
+
+  if (position === null && methodQuality === null) {
+    return null
   }
 
-  const delta = {
+  return {
     updates: [
       {
         source: tags.source,
         timestamp: timestamp,
         values: [
-          {
-            path: 'navigation.position',
-            value: position
-          },
-          {
-            path: 'navigation.gnss.methodQuality',
-            value: indicator(parts[5]!.split(''))
-          },
-
+          { path: 'navigation.position', value: position },
+          { path: 'navigation.gnss.methodQuality', value: methodQuality },
           {
             path: 'navigation.gnss.satellites',
-            value: utils.int(parts[6]!)
+            value: utils.intOrNull(parts[6]!)
           },
-
           {
             path: 'navigation.gnss.antennaAltitude',
-            value: utils.float(parts[8]!)
+            value: utils.floatOrNull(parts[8]!)
           },
-
           {
             path: 'navigation.gnss.horizontalDilution',
-            value: utils.float(parts[7]!)
+            value: utils.floatOrNull(parts[7]!)
           },
-
           {
             path: 'navigation.gnss.geoidalSeparation',
-            value: utils.float(parts[9]!)
+            value: utils.floatOrNull(parts[9]!)
           },
-
           {
             path: 'navigation.gnss.differentialAge',
-            value: utils.float(parts[10]!)
+            value: utils.floatOrNull(parts[10]!)
           },
-
           {
             path: 'navigation.gnss.differentialReference',
-            value: Number(parts[11]!)
+            value: utils.intOrNull(parts[11]!)
           },
           {
             path: 'navigation.gnss.status',
-            value: STATUS[parts[12]!]
+            value: parts[12] !== undefined ? (STATUS[parts[12]!] ?? null) : null
           }
         ]
       }
     ]
   }
-
-  return delta
 }
 
 export default GNS

--- a/src/hooks/GSV.ts
+++ b/src/hooks/GSV.ts
@@ -83,9 +83,15 @@ const TALKER_TO_GNSS: Record<string, string> = {
 
 interface Satellite {
   id: number
-  elevation: number
-  azimuth: number
-  SNR: number
+  // Per IEC 61162-1 §7.2.3.4, elevation / azimuth / SNR are independently
+  // optional — some receivers omit them for just-tracked satellites.
+  // `null` carries that "sensor working, no data" signal instead of
+  // silently reporting 0° elevation (the previous `parts[...] ?? '0'`
+  // fallback was indistinguishable from a satellite genuinely at the
+  // horizon).
+  elevation: number | null
+  azimuth: number | null
+  SNR: number | null
 }
 
 interface GsvAccumulator {
@@ -131,17 +137,17 @@ const GSV: HookFn = function (
       const satPRN = Number(_satPRN)
       gsvData.satellites.push({
         id: satPRN >= 64 ? satPRN - 64 : satPRN,
-        elevation: utils.transform(
-          parts[thisSatDataStart + OFFSET_ELEVATION] ?? '0',
+        elevation: utils.transformOrNull(
+          parts[thisSatDataStart + OFFSET_ELEVATION]!,
           'deg',
           'rad'
         ),
-        azimuth: utils.transform(
-          parts[thisSatDataStart + OFFSET_AZIMUTH] ?? '0',
+        azimuth: utils.transformOrNull(
+          parts[thisSatDataStart + OFFSET_AZIMUTH]!,
           'deg',
           'rad'
         ),
-        SNR: Number(parts[thisSatDataStart + OFFSET_SNR])
+        SNR: utils.floatOrNull(parts[thisSatDataStart + OFFSET_SNR]!)
       })
     }
   }

--- a/src/hooks/HDG.ts
+++ b/src/hooks/HDG.ts
@@ -15,7 +15,13 @@
  */
 
 import * as utils from '@signalk/nmea0183-utilities'
-import type { Delta, HookFn, ParserInput, ParserSession } from '../types'
+import type {
+  Delta,
+  DeltaValue,
+  HookFn,
+  ParserInput,
+  ParserSession
+} from '../types'
 /*
 *******  0 1   2 3   4
 *******  | |   | |   |
@@ -44,7 +50,7 @@ const HDG: HookFn = function (
   const deviationDeg = utils.magneticVariationOrNull(parts[1]!, parts[2]!)
   const variationDeg = utils.magneticVariationOrNull(parts[3]!, parts[4]!)
 
-  const values: Array<{ path: string; value: unknown }> = []
+  const values: DeltaValue[] = []
 
   if (compassDeg !== null) {
     const effectiveDeviation = deviationDeg ?? 0

--- a/src/hooks/HDG.ts
+++ b/src/hooks/HDG.ts
@@ -28,74 +28,69 @@ Field Number:
 4 Magnetic Variation direction, E = Easterly, W = Westerly
 */
 
-function isEmpty(mixed: unknown): boolean {
-  if (typeof mixed === 'number') {
-    return false
-  }
-  return typeof mixed !== 'string' || mixed.trim() === ''
-}
+// Deviation and variation are both signed scalars — magnitude field +
+// direction letter (E = positive, W = negative). The `*OrNull` helpers
+// short-circuit missing fields to null so an empty deviation / variation
+// doesn't silently become 0° of correction (which would publish a wrong
+// `headingMagnetic` when the receiver only has a raw compass reading).
 
 const HDG: HookFn = function (
   input: ParserInput,
   _session: ParserSession
 ): Delta | null {
   const { parts, tags } = input
-  const values = []
 
-  const headingCompass = parts[0]!
-  const deviation = parts[1]!
-  const deviationDir = parts[2]! === 'E' ? 1 : -1
-  const variation = parts[3]!
-  const variationDir = parts[4]! === 'E' ? 1 : -1
-  if (!isEmpty(headingCompass)) {
-    const effectiveDeviation = !isEmpty(deviation)
-      ? Number(deviation) * deviationDir
-      : 0
+  const compassDeg = utils.floatOrNull(parts[0]!)
+  const deviationDeg = utils.magneticVariationOrNull(parts[1]!, parts[2]!)
+  const variationDeg = utils.magneticVariationOrNull(parts[3]!, parts[4]!)
+
+  const values: Array<{ path: string; value: unknown }> = []
+
+  if (compassDeg !== null) {
+    const effectiveDeviation = deviationDeg ?? 0
     values.push({
       path: 'navigation.headingMagnetic',
-      value: utils.transform(
-        utils.float(headingCompass) + effectiveDeviation,
-        'deg',
-        'rad'
-      )
+      value: utils.transform(compassDeg + effectiveDeviation, 'deg', 'rad')
     })
-    if (!isEmpty(deviation)) {
+    // Emit the raw compass heading only when deviation is known — if
+    // deviation is missing, `headingMagnetic` already equals the raw
+    // value and a separate `headingCompass` path adds no information.
+    if (deviationDeg !== null) {
       values.push({
         path: 'navigation.headingCompass',
-        value: utils.transform(utils.float(headingCompass), 'deg', 'rad')
+        value: utils.transform(compassDeg, 'deg', 'rad')
       })
     }
-    if (!isEmpty(variation)) {
-      const effectiveVariation = Number(variation) * variationDir
+    if (variationDeg !== null) {
       values.push({
         path: 'navigation.headingTrue',
         value: utils.transform(
-          utils.float(headingCompass) + effectiveDeviation + effectiveVariation,
+          compassDeg + effectiveDeviation + variationDeg,
           'deg',
           'rad'
         )
       })
     }
   }
-  if (!(isEmpty(variation) || isEmpty(variationDir))) {
+
+  if (variationDeg !== null) {
     values.push({
       path: 'navigation.magneticVariation',
-      value:
-        utils.transform(utils.float(variation), 'deg', 'rad') * variationDir
+      value: utils.transform(variationDeg, 'deg', 'rad')
     })
   }
-  if (!(isEmpty(deviation) || isEmpty(deviationDir))) {
+  if (deviationDeg !== null) {
     values.push({
       path: 'navigation.magneticDeviation',
-      value:
-        utils.transform(utils.float(deviation), 'deg', 'rad') * deviationDir
+      value: utils.transform(deviationDeg, 'deg', 'rad')
     })
   }
-  if (!values.length) {
+
+  if (values.length === 0) {
     return null
   }
 
-  const delta = {
+  return {
     updates: [
       {
         source: tags.source,
@@ -104,8 +99,6 @@ const HDG: HookFn = function (
       }
     ]
   }
-
-  return delta
 }
 
 export default HDG

--- a/src/hooks/HDM.ts
+++ b/src/hooks/HDM.ts
@@ -35,26 +35,20 @@ const HDM: HookFn = function (
 ): Delta | null {
   const { parts, tags } = input
 
-  if (typeof parts[0]! !== 'string' || parts[0]!.trim() === '') {
+  const heading = utils.transformOrNull(parts[0]!, 'deg', 'rad')
+  if (heading === null) {
     return null
   }
 
-  const delta = {
+  return {
     updates: [
       {
         source: tags.source,
         timestamp: tags.timestamp,
-        values: [
-          {
-            path: 'navigation.headingMagnetic',
-            value: utils.transform(utils.float(parts[0]!), 'deg', 'rad')
-          }
-        ]
+        values: [{ path: 'navigation.headingMagnetic', value: heading }]
       }
     ]
   }
-
-  return delta
 }
 
 export default HDM

--- a/src/hooks/HDT.ts
+++ b/src/hooks/HDT.ts
@@ -35,26 +35,20 @@ const HDT: HookFn = function (
 ): Delta | null {
   const { parts, tags } = input
 
-  if (typeof parts[0]! !== 'string' || parts[0]!.trim() === '') {
+  const heading = utils.transformOrNull(parts[0]!, 'deg', 'rad')
+  if (heading === null) {
     return null
   }
 
-  const delta = {
+  return {
     updates: [
       {
         source: tags.source,
         timestamp: tags.timestamp,
-        values: [
-          {
-            path: 'navigation.headingTrue',
-            value: utils.transform(utils.float(parts[0]!), 'deg', 'rad')
-          }
-        ]
+        values: [{ path: 'navigation.headingTrue', value: heading }]
       }
     ]
   }
-
-  return delta
 }
 
 export default HDT

--- a/src/hooks/HSC.ts
+++ b/src/hooks/HSC.ts
@@ -67,11 +67,11 @@ const HSC: HookFn = function (
         values: [
           {
             path: 'steering.autopilot.target.headingTrue',
-            value: headingToSteer['True']
+            value: headingToSteer['True'] ?? null
           },
           {
             path: 'steering.autopilot.target.headingMagnetic',
-            value: headingToSteer['Magnetic']
+            value: headingToSteer['Magnetic'] ?? null
           }
         ]
       }

--- a/src/hooks/HSC.ts
+++ b/src/hooks/HSC.ts
@@ -38,20 +38,26 @@ const HSC: HookFn = function (
 
   debug(`[HSCHook] decoding sentence ${id} => ${sentence}`)
 
-  if (
-    upper(parts[1]!) === '' ||
-    upper(parts[3]!) === '' ||
-    upper(parts[0]!) === '' ||
-    upper(parts[2]!) === ''
-  ) {
+  // Unit letters T / M identify which branch each numeric field
+  // belongs to; either letter missing means the sentence is malformed.
+  const firstUnit = upper(parts[1] ?? '')
+  const secondUnit = upper(parts[3] ?? '')
+  if (firstUnit === '' || secondUnit === '') {
     return null
   }
 
-  const headingToSteer: Record<string, number> = {}
-  headingToSteer[upper(parts[1]!) === 'T' ? 'True' : 'Magnetic'] =
-    utils.transform(parts[0]!, 'deg', 'rad')
-  headingToSteer[upper(parts[3]!) === 'T' ? 'True' : 'Magnetic'] =
-    utils.transform(parts[2]!, 'deg', 'rad')
+  const headingToSteer: Record<string, number | null> = {
+    True: null,
+    Magnetic: null
+  }
+  headingToSteer[firstUnit === 'T' ? 'True' : 'Magnetic'] =
+    utils.transformOrNull(parts[0]!, 'deg', 'rad')
+  headingToSteer[secondUnit === 'T' ? 'True' : 'Magnetic'] =
+    utils.transformOrNull(parts[2]!, 'deg', 'rad')
+
+  if (headingToSteer['True'] === null && headingToSteer['Magnetic'] === null) {
+    return null
+  }
 
   return {
     updates: [
@@ -61,11 +67,11 @@ const HSC: HookFn = function (
         values: [
           {
             path: 'steering.autopilot.target.headingTrue',
-            value: headingToSteer['True'] ?? null
+            value: headingToSteer['True']
           },
           {
             path: 'steering.autopilot.target.headingMagnetic',
-            value: headingToSteer['Magnetic'] ?? null
+            value: headingToSteer['Magnetic']
           }
         ]
       }

--- a/src/hooks/MDA.ts
+++ b/src/hooks/MDA.ts
@@ -38,93 +38,109 @@ import type { Delta, HookFn, ParserInput, ParserSession } from '../types'
  *  12.    Checksum
  */
 
+// inHg -> Pa conversion factor: 1 inHg = 3386.3886666667 Pa.
+const INHG_TO_PA = 3386.3886666667
+
 const MDA: HookFn = function (
   input: ParserInput,
   _session: ParserSession
 ): Delta | null {
   const { parts, tags } = input
+  const values: Array<{ path: string; value: unknown }> = []
 
-  const values = []
-
-  // make SI units override any non-SI units
-  if (parts[0]! !== '') {
+  const inHg = utils.floatOrNull(parts[0]!)
+  if (inHg !== null) {
     values.push({
       path: 'environment.outside.pressure',
-      value: 3386.3886666667 * utils.float(parts[0]!) // converting inHg -> Pa (SI units)
+      value: inHg * INHG_TO_PA
     })
   }
-  if (parts[2]! !== '') {
+  // SI (bars) overrides non-SI (inches of mercury) when both are present.
+  const bars = utils.floatOrNull(parts[2]!)
+  if (bars !== null) {
     values.push({
       path: 'environment.outside.pressure',
-      value: utils.float(parts[2]!) * 100000.0 // converting from bars to Pa (SI units)
+      value: bars * 100000.0
     })
   }
-  if (parts[4]! !== '') {
-    values.push({
-      path: 'environment.outside.temperature',
-      value: utils.transform(utils.float(parts[4]!), 'c', 'k') // transform units Celsius to Kelvin (stick to SI units)
-    })
+
+  const airTemp = utils.transformOrNull(parts[4]!, 'c', 'k')
+  if (airTemp !== null) {
+    values.push({ path: 'environment.outside.temperature', value: airTemp })
   }
-  if (parts[6]! !== '') {
-    values.push({
-      path: 'environment.water.temperature',
-      value: utils.transform(utils.float(parts[6]!), 'c', 'k') // transform units Celsius to Kelvin (stick to SI units)
-    })
+
+  const waterTemp = utils.transformOrNull(parts[6]!, 'c', 'k')
+  if (waterTemp !== null) {
+    values.push({ path: 'environment.water.temperature', value: waterTemp })
   }
-  if (parts[8]! !== '') {
+
+  const humidity = utils.floatOrNull(parts[8]!)
+  if (humidity !== null) {
     values.push({
       path: 'environment.outside.humidity',
-      value: utils.float(parts[8]!) / 100.0 // converting from precentage to fraction
-    })
-  }
-  if (parts[9]! !== '') {
-    values.push({
-      path: 'environment.outside.humidityAbsolute',
-      value: utils.float(parts[9]!) / 100.0 // NMEA docs suggest this is a fraction/percentage, so probably they mean mass water per mass atmosphere formulation
-    })
-  }
-  if (parts[10]! !== '') {
-    values.push({
-      path: 'environment.outside.dewPointTemperature',
-      value: utils.transform(utils.float(parts[10]!), 'c', 'k')
-    })
-  }
-  if (parts[12]! !== '') {
-    values.push({
-      path: 'environment.wind.directionTrue',
-      value: utils.transform(utils.float(parts[12]!), 'deg', 'rad')
-    })
-  }
-  if (parts[14]! !== '') {
-    values.push({
-      path: 'environment.wind.directionMagnetic',
-      value: utils.transform(utils.float(parts[14]!), 'deg', 'rad')
-    })
-  }
-  if (parts[16]! !== '') {
-    values.push({
-      path: 'environment.wind.speedOverGround',
-      value: utils.transform(utils.float(parts[16]!), 'knots', 'ms')
-    })
-  }
-  if (parts[18]! !== '') {
-    values.push({
-      path: 'environment.wind.speedOverGround',
-      value: utils.float(parts[18]!)
+      value: humidity / 100.0
     })
   }
 
-  const delta = {
+  const humidityAbs = utils.floatOrNull(parts[9]!)
+  if (humidityAbs !== null) {
+    values.push({
+      path: 'environment.outside.humidityAbsolute',
+      value: humidityAbs / 100.0
+    })
+  }
+
+  const dewPoint = utils.transformOrNull(parts[10]!, 'c', 'k')
+  if (dewPoint !== null) {
+    values.push({
+      path: 'environment.outside.dewPointTemperature',
+      value: dewPoint
+    })
+  }
+
+  const windDirTrue = utils.transformOrNull(parts[12]!, 'deg', 'rad')
+  if (windDirTrue !== null) {
+    values.push({
+      path: 'environment.wind.directionTrue',
+      value: windDirTrue
+    })
+  }
+
+  const windDirMag = utils.transformOrNull(parts[14]!, 'deg', 'rad')
+  if (windDirMag !== null) {
+    values.push({
+      path: 'environment.wind.directionMagnetic',
+      value: windDirMag
+    })
+  }
+
+  const windKnots = utils.transformOrNull(parts[16]!, 'knots', 'ms')
+  if (windKnots !== null) {
+    values.push({
+      path: 'environment.wind.speedOverGround',
+      value: windKnots
+    })
+  }
+
+  // m/s overrides knots when both are present (same override pattern as bars vs inHg).
+  const windMs = utils.floatOrNull(parts[18]!)
+  if (windMs !== null) {
+    values.push({ path: 'environment.wind.speedOverGround', value: windMs })
+  }
+
+  if (values.length === 0) {
+    return null
+  }
+
+  return {
     updates: [
       {
         source: tags.source,
         timestamp: tags.timestamp,
-        values: values
+        values
       }
     ]
   }
-
-  return delta
 }
 
 export default MDA

--- a/src/hooks/MDA.ts
+++ b/src/hooks/MDA.ts
@@ -15,7 +15,13 @@
  */
 
 import * as utils from '@signalk/nmea0183-utilities'
-import type { Delta, HookFn, ParserInput, ParserSession } from '../types'
+import type {
+  Delta,
+  DeltaValue,
+  HookFn,
+  ParserInput,
+  ParserSession
+} from '../types'
 
 /*
  * MDA - Meteorological Composite
@@ -46,7 +52,7 @@ const MDA: HookFn = function (
   _session: ParserSession
 ): Delta | null {
   const { parts, tags } = input
-  const values: Array<{ path: string; value: unknown }> = []
+  const values: DeltaValue[] = []
 
   const inHg = utils.floatOrNull(parts[0]!)
   if (inHg !== null) {

--- a/src/hooks/MTA.ts
+++ b/src/hooks/MTA.ts
@@ -37,28 +37,23 @@ const MTA: HookFn = function (
 ): Delta | null {
   const { parts, tags } = input
 
-  if (parts[1]! != 'C') {
+  if (parts[1]! !== 'C') {
     return null
   }
-  const delta = {
+
+  const temperature = utils.transformOrNull(parts[0]!, 'c', 'k')
+
+  return {
     updates: [
       {
         source: tags.source,
         timestamp: tags.timestamp,
         values: [
-          {
-            path: 'environment.outside.temperature',
-            value:
-              parts.length > 0 && parts[0]!.trim().length > 0
-                ? utils.transform(utils.float(parts[0]!), 'c', 'k')
-                : null
-          }
+          { path: 'environment.outside.temperature', value: temperature }
         ]
       }
     ]
   }
-
-  return delta
 }
 
 export default MTA

--- a/src/hooks/MTW.ts
+++ b/src/hooks/MTW.ts
@@ -37,25 +37,17 @@ const MTW: HookFn = function (
 ): Delta | null {
   const { parts, tags } = input
 
-  const delta = {
+  const temperature = utils.transformOrNull(parts[0]!, 'c', 'k')
+
+  return {
     updates: [
       {
         source: tags.source,
         timestamp: tags.timestamp,
-        values: [
-          {
-            path: 'environment.water.temperature',
-            value:
-              parts.length > 0 && parts[0]!.trim().length > 0
-                ? utils.transform(utils.float(parts[0]!), 'c', 'k')
-                : null
-          }
-        ]
+        values: [{ path: 'environment.water.temperature', value: temperature }]
       }
     ]
   }
-
-  return delta
 }
 
 export default MTW

--- a/src/hooks/MWD.ts
+++ b/src/hooks/MWD.ts
@@ -36,60 +36,51 @@ const MWD: HookFn = function (
   _session: ParserSession
 ): Delta | null {
   const { parts, tags } = input
-  const pathValues: Array<{ path: string; value: unknown }> = []
 
-  // get direction data:
-  // return both, true and magnetic direction, if present in the NMEA sentence
-  var haveDirection = false
-  if (parts[0]! != '' && parts[1]! == 'T') {
-    haveDirection = true
-    pathValues.push({
+  const directionTrue =
+    parts[1]! === 'T' ? utils.transformOrNull(parts[0]!, 'deg', 'rad') : null
+  const directionMagnetic =
+    parts[3]! === 'M' ? utils.transformOrNull(parts[2]!, 'deg', 'rad') : null
+
+  if (directionTrue === null && directionMagnetic === null) {
+    return null
+  }
+
+  // Prefer m/s over knots when both are present — the native unit
+  // avoids an extra conversion round-trip.
+  const msSpeed = parts[7]! === 'M' ? utils.floatOrNull(parts[6]!) : null
+  const knotsSpeed =
+    parts[5]! === 'N' ? utils.transformOrNull(parts[4]!, 'knots', 'ms') : null
+  const speed = msSpeed ?? knotsSpeed
+
+  if (speed === null) {
+    return null
+  }
+
+  const values: Array<{ path: string; value: unknown }> = []
+  if (directionTrue !== null) {
+    values.push({
       path: 'environment.wind.directionTrue',
-      value: utils.transform(utils.float(parts[0]!), 'deg', 'rad')
+      value: directionTrue
     })
   }
-  if (parts[2]! != '' && parts[3]! == 'M') {
-    haveDirection = true
-    pathValues.push({
+  if (directionMagnetic !== null) {
+    values.push({
       path: 'environment.wind.directionMagnetic',
-      value: utils.transform(utils.float(parts[2]!), 'deg', 'rad')
+      value: directionMagnetic
     })
   }
-  if (!haveDirection) {
-    return null
-  }
+  values.push({ path: 'environment.wind.speedTrue', value: speed })
 
-  // get speed data:
-  // speed given in kn is used in case no speed in m/s is present in the NMEA sentence
-  var haveSpeed = false
-  var speed
-  if (parts[4]! != '' && parts[5]! == 'N') {
-    haveSpeed = true
-    speed = utils.transform(utils.float(parts[4]!), 'knots', 'ms')
-  }
-  if (parts[6]! != '' && parts[7]! == 'M') {
-    haveSpeed = true
-    speed = utils.float(parts[6]!)
-  }
-  if (!haveSpeed) {
-    return null
-  }
-  pathValues.push({
-    path: 'environment.wind.speedTrue',
-    value: speed
-  })
-
-  const delta = {
+  return {
     updates: [
       {
         source: tags.source,
         timestamp: tags.timestamp,
-        values: pathValues
+        values
       }
     ]
   }
-
-  return delta
 }
 
 export default MWD

--- a/src/hooks/MWD.ts
+++ b/src/hooks/MWD.ts
@@ -15,7 +15,13 @@
  */
 
 import * as utils from '@signalk/nmea0183-utilities'
-import type { Delta, HookFn, ParserInput, ParserSession } from '../types'
+import type {
+  Delta,
+  DeltaValue,
+  HookFn,
+  ParserInput,
+  ParserSession
+} from '../types'
 /*
  * $WIMWD,<0>,<1>,<2>,<3>,<4>,<5>,<6>,<7>*hh
  *
@@ -57,7 +63,7 @@ const MWD: HookFn = function (
     return null
   }
 
-  const values: Array<{ path: string; value: unknown }> = []
+  const values: DeltaValue[] = []
   if (directionTrue !== null) {
     values.push({
       path: 'environment.wind.directionTrue',

--- a/src/hooks/MWV.ts
+++ b/src/hooks/MWV.ts
@@ -17,12 +17,16 @@
 import * as utils from '@signalk/nmea0183-utilities'
 import type { UnitFormat } from '@signalk/nmea0183-utilities'
 import type { Delta, HookFn, ParserInput, ParserSession } from '../types'
-function convertToWindAngle(angle: number | string): number {
-  const numAngle = utils.float(angle) % 360
-  if (numAngle > 180 && numAngle <= 360) {
-    return numAngle - 360
-  }
-  return numAngle
+
+// MWV is only emitted when the status field (parts[4]) is 'A' (valid).
+// Within a valid sentence, angle and speed are each routed through the
+// `*OrNull` helpers so an empty optional field becomes `null` rather
+// than a silent 0 (the old code would report e.g. 0° apparent wind
+// angle when the angle field was empty).
+
+function convertToWindAngle(angle: number): number {
+  const numAngle = angle % 360
+  return numAngle > 180 && numAngle <= 360 ? numAngle - 360 : numAngle
 }
 
 const MWV: HookFn = function (
@@ -36,40 +40,35 @@ const MWV: HookFn = function (
   }
 
   const mwvCode = parts[3]!.toUpperCase()
-  let wsu: UnitFormat
-  if (mwvCode === 'K') {
-    wsu = 'kph'
-  } else if (mwvCode === 'N') {
-    wsu = 'knots'
-  } else {
-    wsu = 'ms'
+  const wsu: UnitFormat =
+    mwvCode === 'K' ? 'kph' : mwvCode === 'N' ? 'knots' : 'ms'
+
+  const rawAngleDeg = utils.floatOrNull(parts[0]!)
+  const angle =
+    rawAngleDeg === null
+      ? null
+      : utils.transform(convertToWindAngle(rawAngleDeg), 'deg', 'rad')
+  const speed = utils.transformOrNull(parts[2]!, wsu, 'ms')
+
+  const valueType = parts[1]!.toUpperCase() === 'R' ? 'Apparent' : 'True'
+  const angleType = parts[1]!.toUpperCase() === 'R' ? 'Apparent' : 'TrueWater'
+
+  if (angle === null && speed === null) {
+    return null
   }
 
-  const angle = convertToWindAngle(parts[0]!)
-  const speed = utils.transform(parts[2]!, wsu, 'ms')
-  const valueType = parts[1]!.toUpperCase() == 'R' ? 'Apparent' : 'True'
-  const angleType = parts[1]!.toUpperCase() == 'R' ? 'Apparent' : 'TrueWater'
-
-  const delta = {
+  return {
     updates: [
       {
         source: tags.source,
         timestamp: tags.timestamp,
         values: [
-          {
-            path: 'environment.wind.speed' + valueType,
-            value: speed
-          },
-          {
-            path: 'environment.wind.angle' + angleType,
-            value: utils.transform(angle, 'deg', 'rad')
-          }
+          { path: 'environment.wind.speed' + valueType, value: speed },
+          { path: 'environment.wind.angle' + angleType, value: angle }
         ]
       }
     ]
   }
-
-  return delta
 }
 
 export default MWV

--- a/src/hooks/RMB.ts
+++ b/src/hooks/RMB.ts
@@ -16,7 +16,13 @@
 
 import * as utils from '@signalk/nmea0183-utilities'
 import { coord } from '../lib/nmea-casts'
-import type { Delta, HookFn, ParserInput, ParserSession } from '../types'
+import type {
+  Delta,
+  DeltaValue,
+  HookFn,
+  ParserInput,
+  ParserSession
+} from '../types'
 
 /*
 RMB Sentence
@@ -73,7 +79,7 @@ const RMB: HookFn = function (
   const originWaypointID = (parts[3]! || '').trim()
   const destinationWaypointID = (parts[4]! || '').trim()
 
-  const values: Array<{ path: string; value: unknown }> = [
+  const values: DeltaValue[] = [
     { path: 'navigation.courseRhumbline.nextPoint.position', value: position },
     {
       path: 'navigation.courseRhumbline.nextPoint.bearingTrue',

--- a/src/hooks/RMB.ts
+++ b/src/hooks/RMB.ts
@@ -21,22 +21,17 @@ import type { Delta, HookFn, ParserInput, ParserSession } from '../types'
 /*
 RMB Sentence
 $GPRMB,A,0.66,L,003,004,4917.24,N,12309.57,W,001.3,052.5,000.5,V*20
-values:
 
--      RMB          Recommended minimum navigation information
-[0]    A            Data status A = OK, V = Void (warning)
-[1][2] 0.66,L       Cross-track error (nautical miles, 9.99 max),
-                    steer Left to correct (or R = right)
-[3]    003          Origin waypoint ID
-[4]    004          Destination waypoint ID
-[5][6] 4917.24,N    Destination waypoint latitude 49 deg. 17.24 min. N
-[7][8] 12309.57,W   Destination waypoint longitude 123 deg. 09.57 min. W
-[9]    001.3        Range to destination, nautical miles (999.9 max)
-[10]   052.5        True bearing to destination
-[11]   000.5        Velocity towards destination, knots
-[12]   V            Arrival alarm  A = arrived, V = not arrived
--      *20          checksum
-
+[0]    Data status A = OK, V = Void
+[1][2] Cross-track error magnitude, steer direction L / R
+[3]    Origin waypoint ID
+[4]    Destination waypoint ID
+[5][6] Destination waypoint latitude / pole
+[7][8] Destination waypoint longitude / pole
+[9]    Range to destination, nautical miles
+[10]   True bearing to destination
+[11]   Velocity towards destination, knots
+[12]   Arrival alarm A = arrived, V = not arrived
 */
 
 const RMB: HookFn = function (
@@ -45,50 +40,56 @@ const RMB: HookFn = function (
 ): Delta | null {
   const { parts, tags } = input
 
-  let position = null
+  const position =
+    parts[5]!.trim() !== '' && parts[7]!.trim() !== ''
+      ? {
+          longitude: coord(parts[7]!, parts[8]!),
+          latitude: coord(parts[5]!, parts[6]!)
+        }
+      : null
 
-  if (parts[5]!.trim() !== '' && parts[7]!.trim() !== '') {
-    position = {
-      longitude: coord(parts[7]!, parts[8]!),
-      latitude: coord(parts[5]!, parts[6]!)
-    }
-  }
+  const bearing = utils.transformOrNull(parts[10]!, 'deg', 'rad')
+  // VMG negative values indicate moving away from the destination. The
+  // previous code clamped them to 0 — we keep that behaviour because
+  // the Signal K path is "velocity made good" and a negative figure
+  // would be unusual for downstream autopilot logic, but a truly
+  // missing field now surfaces as null.
+  const rawVmg = utils.floatOrNull(parts[11]!)
+  const vmg =
+    rawVmg === null
+      ? null
+      : utils.transform(rawVmg > 0 ? rawVmg : 0, 'knots', 'ms')
+  const distanceNm = utils.floatOrNull(parts[9]!)
+  const distance =
+    distanceNm === null ? null : utils.transform(distanceNm, 'nm', 'm')
 
-  const bearing = utils.float(parts[10]!)
-  const rawVmg = utils.float(parts[11]!)
-  const vmg = rawVmg > 0 ? rawVmg : 0.0
-  const distance = utils.float(parts[9]!)
-  const rawCrossTrackError = utils.float(parts[1]!)
+  const rawXte = utils.floatOrNull(parts[1]!)
+  const directionLetter = parts[2]!
   const crossTrackError =
-    parts[2]! == 'L' ? rawCrossTrackError : -rawCrossTrackError
+    rawXte === null
+      ? null
+      : utils.transform(directionLetter === 'L' ? rawXte : -rawXte, 'nm', 'm')
 
   const originWaypointID = (parts[3]! || '').trim()
   const destinationWaypointID = (parts[4]! || '').trim()
 
   const values: Array<{ path: string; value: unknown }> = [
-    {
-      path: 'navigation.courseRhumbline.nextPoint.position',
-      value: position
-    },
-
+    { path: 'navigation.courseRhumbline.nextPoint.position', value: position },
     {
       path: 'navigation.courseRhumbline.nextPoint.bearingTrue',
-      value: utils.transform(bearing, 'deg', 'rad')
+      value: bearing
     },
-
     {
       path: 'navigation.courseRhumbline.nextPoint.velocityMadeGood',
-      value: utils.transform(vmg, 'knots', 'ms')
+      value: vmg
     },
-
     {
       path: 'navigation.courseRhumbline.nextPoint.distance',
-      value: utils.transform(distance, 'nm', 'km') * 1000
+      value: distance
     },
-
     {
       path: 'navigation.courseRhumbline.crossTrackError',
-      value: utils.transform(crossTrackError, 'nm', 'km') * 1000
+      value: crossTrackError
     }
   ]
 
@@ -98,7 +99,6 @@ const RMB: HookFn = function (
       value: destinationWaypointID
     })
   }
-
   if (originWaypointID) {
     values.push({
       path: 'navigation.courseRhumbline.previousPoint.ID',
@@ -106,7 +106,7 @@ const RMB: HookFn = function (
     })
   }
 
-  const delta = {
+  return {
     updates: [
       {
         source: tags.source,
@@ -115,8 +115,6 @@ const RMB: HookFn = function (
       }
     ]
   }
-
-  return delta
 }
 
 export default RMB

--- a/src/hooks/RMC.ts
+++ b/src/hooks/RMC.ts
@@ -15,7 +15,7 @@
  */
 
 import * as utils from '@signalk/nmea0183-utilities'
-import { coord, magVar } from '../lib/nmea-casts'
+import { coord } from '../lib/nmea-casts'
 import type { Delta, HookFn, ParserInput, ParserSession } from '../types'
 
 /*
@@ -35,99 +35,60 @@ values:
  -      *6A          The checksum data, always begins with *
 */
 
+// Every optional numeric field goes through the `*OrNull` helpers so an
+// empty NMEA field (IEC 61162-1 §7.2.3.4) maps to a Signal K `null`
+// instead of a silent `0`. Reported in SignalK/nmea0183-signalk#192 —
+// an empty magnetic-variation field was being emitted as 0°, causing a
+// 13° course error for a reporter in a high-variation area.
+
 const RMC: HookFn = function (
   input: ParserInput,
   _session: ParserSession
 ): Delta | null {
   const { parts, tags } = input
 
-  let latitude = null
-  let longitude = null
-  let speed = null
-  let track = null
-  let variation = null
-
   const timestamp = utils.timestamp(parts[0]!, parts[8]!)
   // seconds since epoch; Date.parse avoids an extra Date allocation
   const age = Math.floor(Date.parse(timestamp) / 1000)
 
-  // NMEA numeric fields are transported as strings. `coord` already
-  // validates the pole letter (returns null for unexpected chars), so we
-  // only need the non-empty/numeric guards here.
-  latitude =
-    parts[2]!.trim().length > 0 && !isNaN(Number(parts[2]!))
-      ? coord(parts[2]!, parts[3]!)
-      : null
-  longitude =
-    parts[4]!.trim().length > 0 && !isNaN(Number(parts[4]!))
-      ? coord(parts[4]!, parts[5]!)
-      : null
+  const latitude = coord(parts[2]!, parts[3]!)
+  const longitude = coord(parts[4]!, parts[5]!)
 
-  speed =
-    parts[6]!.trim().length > 0 &&
-    !isNaN(Number(parts[6]!)) &&
-    Number(parts[6]!) >= 0
-      ? utils.transform(parts[6]!, 'knots', 'ms')
-      : null
+  // Negative SOG is not a legitimate measurement (speed is a magnitude);
+  // treat as not-available rather than flipping sign.
+  const sog = utils.floatOrNull(parts[6]!)
+  const speed =
+    sog === null || sog < 0 ? null : utils.transform(sog, 'knots', 'ms')
 
-  track =
-    parts[7]!.trim().length > 0 && !isNaN(Number(parts[7]!))
-      ? utils.transform(parts[7]!, 'deg', 'rad')
+  const track = utils.transformOrNull(parts[7]!, 'deg', 'rad')
+
+  const variationDeg = utils.magneticVariationOrNull(parts[9]!, parts[10]!)
+  const variation =
+    variationDeg === null ? null : utils.transform(variationDeg, 'deg', 'rad')
+
+  const position =
+    latitude !== null &&
+    longitude !== null &&
+    utils.isValidPosition(latitude, longitude)
+      ? { latitude, longitude }
       : null
 
-  {
-    const degs =
-      parts[9]!.trim().length > 0 && !isNaN(Number(parts[9]!))
-        ? magVar(parts[9]!, parts[10]!)
-        : null
-    variation = degs === null ? null : utils.transform(degs, 'deg', 'rad')
-  }
-
-  let position = null
-
-  if (utils.isValidPosition(latitude, longitude)) {
-    position = {
-      latitude: latitude,
-      longitude: longitude
-    }
-  }
-
-  const delta = {
+  return {
     updates: [
       {
         source: tags.source,
         timestamp: timestamp,
         values: [
-          {
-            path: 'navigation.position',
-            value: position
-          },
-          {
-            path: 'navigation.courseOverGroundTrue',
-            value: track
-          },
-          {
-            path: 'navigation.speedOverGround',
-            value: speed
-          },
-          {
-            path: 'navigation.magneticVariation',
-            value: variation
-          },
-          {
-            path: 'navigation.magneticVariationAgeOfService',
-            value: age
-          },
-          {
-            path: 'navigation.datetime',
-            value: timestamp
-          }
+          { path: 'navigation.position', value: position },
+          { path: 'navigation.courseOverGroundTrue', value: track },
+          { path: 'navigation.speedOverGround', value: speed },
+          { path: 'navigation.magneticVariation', value: variation },
+          { path: 'navigation.magneticVariationAgeOfService', value: age },
+          { path: 'navigation.datetime', value: timestamp }
         ]
       }
     ]
   }
-
-  return delta
 }
 
 export default RMC

--- a/src/hooks/ROT.ts
+++ b/src/hooks/ROT.ts
@@ -27,8 +27,6 @@ import type { Delta, HookFn, ParserInput, ParserSession } from '../types'
 # 0 - Rate Of Turn, degrees per minute, "-" means bow turns to port
 # 1 - Status, A means data is valid
 # 2 - Checksum
-#
-#
 */
 
 const ROT: HookFn = function (
@@ -41,22 +39,20 @@ const ROT: HookFn = function (
     return null
   }
 
-  const delta = {
+  // deg/min -> rad/s (transform deg->rad, divide by 60 s/min). Missing
+  // value short-circuits to null instead of emitting 0 rad/s.
+  const radPerMin = utils.transformOrNull(parts[0]!, 'deg', 'rad')
+  const rateOfTurn = radPerMin === null ? null : radPerMin / 60
+
+  return {
     updates: [
       {
         source: tags.source,
         timestamp: tags.timestamp,
-        values: [
-          {
-            path: 'navigation.rateOfTurn',
-            value: utils.transform(utils.float(parts[0]!), 'deg', 'rad') / 60
-          }
-        ]
+        values: [{ path: 'navigation.rateOfTurn', value: rateOfTurn }]
       }
     ]
   }
-
-  return delta
 }
 
 export default ROT

--- a/src/hooks/RPM.ts
+++ b/src/hooks/RPM.ts
@@ -32,7 +32,10 @@ const RPM: HookFn = function (
 ): Delta | null {
   const { parts, tags } = input
 
-  const delta = {
+  const rpm = utils.floatOrNull(parts[2]!)
+  const revolutions = rpm === null ? null : rpm / 60
+
+  return {
     updates: [
       {
         source: tags.source,
@@ -42,14 +45,12 @@ const RPM: HookFn = function (
             path: `propulsion.${
               parts[0]!.toUpperCase() === 'S' ? 'shaft' : 'engine'
             }_${parts[1]!}.revolutions`,
-            value: utils.float(parts[2]!) / 60
+            value: revolutions
           }
         ]
       }
     ]
   }
-
-  return delta
 }
 
 export default RPM

--- a/src/hooks/RSA.ts
+++ b/src/hooks/RSA.ts
@@ -40,7 +40,7 @@ const RSA: HookFn = function (
     return null
   }
 
-  const delta = {
+  return {
     updates: [
       {
         source: tags.source,
@@ -48,14 +48,12 @@ const RSA: HookFn = function (
         values: [
           {
             path: 'steering.rudderAngle',
-            value: utils.transform(utils.float(parts[0]!), 'deg', 'rad')
+            value: utils.transformOrNull(parts[0]!, 'deg', 'rad')
           }
         ]
       }
     ]
   }
-
-  return delta
 }
 
 export default RSA

--- a/src/hooks/VDM.ts
+++ b/src/hooks/VDM.ts
@@ -17,7 +17,13 @@
 import * as utils from '@signalk/nmea0183-utilities'
 import * as schema from '@signalk/signalk-schema'
 import { AisDecode } from 'ggencoder'
-import type { Delta, HookFn, ParserInput, ParserSession } from '../types'
+import type {
+  Delta,
+  DeltaValue,
+  HookFn,
+  ParserInput,
+  ParserSession
+} from '../types'
 
 type NumericInput = number | string
 const knotsToMs = (v: NumericInput): number =>
@@ -185,7 +191,7 @@ const VDM: HookFn = function (
   // AIS message type; cast to a looser bag so downstream bit-math reads as
   // naturally as it did in JS. Runtime behaviour is identical.
   const data = new AisDecode(sentence, session) as unknown as AisDecodeData
-  const values: Array<{ path: string; value: unknown }> = []
+  const values: DeltaValue[] = []
 
   if (data.valid === false) {
     return null
@@ -389,7 +395,7 @@ const VDM: HookFn = function (
   if (typeof data.smi !== 'undefined') {
     values.push({
       path: 'navigation.specialManeuver',
-      value: specialManeuverMapping[data.smi]
+      value: specialManeuverMapping[data.smi] ?? null
     })
   }
 
@@ -475,7 +481,7 @@ const VDM: HookFn = function (
       values.push(
         {
           path: `environment.` + path,
-          value: f[data[propName]]
+          value: f[data[propName]] ?? null
         },
         {
           path: `environment.` + path + `Value`,

--- a/src/hooks/VDR.ts
+++ b/src/hooks/VDR.ts
@@ -32,13 +32,25 @@ Field Number:
 6 - Checksum
 */
 
+// Per IEC 61162-1 §7.2.3.4, every optional numeric field is null-preserving
+// so that a receiver reporting e.g. only magnetic set doesn't silently
+// fabricate a true-set of 0°.
+
 const VDR: HookFn = function (
   input: ParserInput,
   _session: ParserSession
 ): Delta | null {
   const { parts, tags } = input
 
-  const delta = {
+  const setTrue = utils.transformOrNull(parts[0]!, 'deg', 'rad')
+  const setMagnetic = utils.transformOrNull(parts[2]!, 'deg', 'rad')
+  const drift = utils.transformOrNull(parts[4]!, 'knots', 'ms')
+
+  if (setTrue === null && setMagnetic === null && drift === null) {
+    return null
+  }
+
+  return {
     updates: [
       {
         source: tags.source,
@@ -47,21 +59,15 @@ const VDR: HookFn = function (
           {
             path: 'environment.current',
             value: {
-              setTrue: utils.transform(utils.float(parts[0]!), 'deg', 'rad'),
-              setMagnetic: utils.transform(
-                utils.float(parts[2]!),
-                'deg',
-                'rad'
-              ),
-              drift: utils.transform(utils.float(parts[4]!), 'knots', 'ms')
+              setTrue,
+              setMagnetic,
+              drift
             }
           }
         ]
       }
     ]
   }
-
-  return delta
 }
 
 export default VDR

--- a/src/hooks/VHW.ts
+++ b/src/hooks/VHW.ts
@@ -37,43 +37,43 @@ Field Number:
 8. Checksum
 */
 
+// IEC 61162-1 §7.2.3.4: emit `null` per field for missing optional
+// measurements. Previously the hook skipped missing paths entirely,
+// which made the delta shape depend on which fields the sensor
+// happened to populate; `null` is more informative (sensor working,
+// value unavailable) and keeps the delta shape stable.
+
 const VHW: HookFn = function (
   input: ParserInput,
   _session: ParserSession
 ): Delta | null {
   const { parts, tags } = input
-  const pathValues: Array<{ path: string; value: unknown }> = []
 
-  if (parts[0]! != '') {
-    pathValues.push({
-      path: 'navigation.headingTrue',
-      value: utils.transform(utils.float(parts[0]!), 'deg', 'rad')
-    })
-  }
-  if (parts[2]! != '') {
-    pathValues.push({
-      path: 'navigation.headingMagnetic',
-      value: utils.transform(utils.float(parts[2]!), 'deg', 'rad')
-    })
-  }
-  if (parts[4]! != '') {
-    pathValues.push({
-      path: 'navigation.speedThroughWater',
-      value: utils.transform(utils.float(parts[4]!), 'knots', 'ms')
-    })
+  const headingTrue = utils.transformOrNull(parts[0]!, 'deg', 'rad')
+  const headingMagnetic = utils.transformOrNull(parts[2]!, 'deg', 'rad')
+  const speedThroughWater = utils.transformOrNull(parts[4]!, 'knots', 'ms')
+
+  if (
+    headingTrue === null &&
+    headingMagnetic === null &&
+    speedThroughWater === null
+  ) {
+    return null
   }
 
-  const delta = {
+  return {
     updates: [
       {
         source: tags.source,
         timestamp: tags.timestamp,
-        values: pathValues
+        values: [
+          { path: 'navigation.headingTrue', value: headingTrue },
+          { path: 'navigation.headingMagnetic', value: headingMagnetic },
+          { path: 'navigation.speedThroughWater', value: speedThroughWater }
+        ]
       }
     ]
   }
-
-  return delta
 }
 
 export default VHW

--- a/src/hooks/VLW.ts
+++ b/src/hooks/VLW.ts
@@ -38,19 +38,14 @@ const VLW: HookFn = function (
   _session: ParserSession
 ): Delta | null {
   const { parts, tags } = input
-  const pathValues: Array<{ path: string; value: unknown }> = []
 
-  if (parts[0]! != '') {
-    pathValues.push({
-      path: 'navigation.log',
-      value: utils.transform(utils.float(parts[0]!), 'nm', 'm')
-    })
-  }
-  if (parts[2]! != '') {
-    pathValues.push({
-      path: 'navigation.trip.log',
-      value: utils.transform(utils.float(parts[2]!), 'nm', 'm')
-    })
+  // Per IEC 61162-1 §7.2.3.4, missing optional fields surface as `null`
+  // so consumers can tell "receiver doesn't know" apart from "0 nm".
+  const cumulative = utils.transformOrNull(parts[0]!, 'nm', 'm')
+  const trip = utils.transformOrNull(parts[2]!, 'nm', 'm')
+
+  if (cumulative === null && trip === null) {
+    return null
   }
 
   return {
@@ -58,7 +53,10 @@ const VLW: HookFn = function (
       {
         source: tags.source,
         timestamp: tags.timestamp,
-        values: pathValues
+        values: [
+          { path: 'navigation.log', value: cumulative },
+          { path: 'navigation.trip.log', value: trip }
+        ]
       }
     ]
   }

--- a/src/hooks/VTG.ts
+++ b/src/hooks/VTG.ts
@@ -36,30 +36,39 @@ import type { Delta, HookFn, ParserInput, ParserSession } from '../types'
  9. Checksum
  */
 
+// Per IEC 61162-1 §7.2.3.4, every optional numeric field is routed
+// through `*OrNull` so an empty NMEA field becomes `null` rather than a
+// silent `0`. Previously `speedOverGround` defaulted to `0.0` when both
+// speed fields were empty but at least one course was present — a fix
+// the parser would report as stationary instead of unknown.
+
 const VTG: HookFn = function (
   input: ParserInput,
   _session: ParserSession
 ): Delta | null {
   const { parts, tags } = input
 
-  if (
-    parts[2]! === '' &&
-    parts[0]! === '' &&
-    parts[6]! === '' &&
-    parts[4]! === ''
-  ) {
-    return null
+  const courseTrue = utils.transformOrNull(parts[0]!, 'deg', 'rad')
+  const courseMagnetic = utils.transformOrNull(parts[2]!, 'deg', 'rad')
+
+  // Prefer kph when its unit letter is 'K' and the field parses. Fall
+  // back to knots the same way. Legitimate zero (receiver is stationary)
+  // returns `0`; null means the field was empty.
+  const kph = utils.floatOrNull(parts[6]!)
+  const knots = utils.floatOrNull(parts[4]!)
+  let speedOverGround: number | null = null
+  if (kph !== null && String(parts[7]!).toUpperCase() === 'K') {
+    speedOverGround = utils.transform(kph, 'kph', 'ms')
+  } else if (knots !== null && String(parts[5]!).toUpperCase() === 'N') {
+    speedOverGround = utils.transform(knots, 'knots', 'ms')
   }
 
-  let speed = 0.0
-
-  if (utils.float(parts[6]!) > 0 && String(parts[7]!).toUpperCase() === 'K') {
-    speed = utils.transform(utils.float(parts[6]!), 'kph', 'ms')
-  } else if (
-    utils.float(parts[4]!) > 0 &&
-    String(parts[5]!).toUpperCase() === 'N'
+  if (
+    courseTrue === null &&
+    courseMagnetic === null &&
+    speedOverGround === null
   ) {
-    speed = utils.transform(utils.float(parts[4]!), 'knots', 'ms')
+    return null
   }
 
   return {
@@ -70,21 +79,15 @@ const VTG: HookFn = function (
         values: [
           {
             path: 'navigation.courseOverGroundMagnetic',
-            value:
-              parts[2]!.length === 0
-                ? null
-                : utils.transform(utils.float(parts[2]!), 'deg', 'rad')
+            value: courseMagnetic
           },
           {
             path: 'navigation.courseOverGroundTrue',
-            value:
-              parts[0]!.length === 0
-                ? null
-                : utils.transform(utils.float(parts[0]!), 'deg', 'rad')
+            value: courseTrue
           },
           {
             path: 'navigation.speedOverGround',
-            value: speed
+            value: speedOverGround
           }
         ]
       }

--- a/src/hooks/VWR.ts
+++ b/src/hooks/VWR.ts
@@ -32,9 +32,12 @@ $--VWR,x.x,a,x.x,N,x.x,M,x.x,K*hh<CR><LF>
  8 - Checksum
  */
 
-function isEmpty(mixed: unknown): boolean {
-  return typeof mixed !== 'string' || mixed.trim() === ''
-}
+// IEC 61162-1 §7.2.3.4: a null field means "sensor working, no data".
+// A sensor reporting only speed (no direction) or only angle (no
+// magnitude) used to be dropped by the pre-existing `empty > 4`
+// count-gate even though the present fields are usable. The hook now
+// emits per-field `null` for the missing half and only short-circuits
+// when both halves are missing.
 
 const VWR: HookFn = function (
   input: ParserInput,
@@ -42,19 +45,20 @@ const VWR: HookFn = function (
 ): Delta | null {
   const { parts, tags } = input
 
-  const empty = parts.reduce((count, part) => {
-    count += isEmpty(part) ? 1 : 0
-    return count
-  }, 0)
-  if (empty > 4) {
-    return null
-  }
+  // Angle needs both the magnitude and the L/R direction letter; either
+  // missing is a null measurement. `transformOrNull` preserves null
+  // through the deg→rad conversion, so we only sign-flip when both
+  // halves are present.
+  const magnitudeRad = utils.transformOrNull(parts[0]!, 'deg', 'rad')
+  const directionLetter = String(parts[1] ?? '').toUpperCase()
+  const sign = directionLetter === 'R' ? 1 : directionLetter === 'L' ? -1 : null
+  const angleApparent =
+    magnitudeRad === null || sign === null ? null : magnitudeRad * sign
 
-  var rightPositive = 0
-  if (String(parts[1]!).toUpperCase() === 'R') {
-    rightPositive = 1
-  } else if (String(parts[1]!).toUpperCase() === 'L') {
-    rightPositive = -1
+  const speedApparent = utils.transformOrNull(parts[2]!, 'knots', 'ms')
+
+  if (angleApparent === null && speedApparent === null) {
+    return null
   }
 
   return {
@@ -65,15 +69,11 @@ const VWR: HookFn = function (
         values: [
           {
             path: 'environment.wind.angleApparent',
-            value: utils.transform(
-              utils.float(parts[0]!) * rightPositive,
-              'deg',
-              'rad'
-            )
+            value: angleApparent
           },
           {
             path: 'environment.wind.speedApparent',
-            value: utils.transform(utils.float(parts[2]!), 'knots', 'ms')
+            value: speedApparent
           }
         ]
       }

--- a/src/hooks/VWR.ts
+++ b/src/hooks/VWR.ts
@@ -36,31 +36,34 @@ function isEmpty(mixed: unknown): boolean {
   return typeof mixed !== 'string' || mixed.trim() === ''
 }
 
+// IEC 61162-1 §7.2.3.4: a null field means "sensor working, no data".
+// A sensor reporting only speed (no direction) or only angle (no
+// magnitude) used to be dropped by the pre-existing `empty > 4`
+// count-gate even though the present fields are usable. The hook now
+// emits per-field `null` for the missing half and only short-circuits
+// when both halves are missing.
+
 const VWR: HookFn = function (
   input: ParserInput,
   _session: ParserSession
 ): Delta | null {
   const { parts, tags } = input
 
-  const empty = parts.reduce((count, part) => {
-    count += isEmpty(part) ? 1 : 0
-    return count
-  }, 0)
-  if (empty > 4) {
-    return null
-  }
-
-  var rightPositive = 0
-  if (String(parts[1]!).toUpperCase() === 'R') {
-    rightPositive = 1
-  } else if (String(parts[1]!).toUpperCase() === 'L') {
-    rightPositive = -1
-  }
+  // Angle needs both the magnitude and the L/R direction letter; either
+  // missing is a null measurement. `transformOrNull` preserves null
+  // through the deg→rad conversion, so we only sign-flip when both
+  // halves are present.
+  const magnitudeRad = utils.transformOrNull(parts[0]!, 'deg', 'rad')
+  const directionLetter = String(parts[1] ?? '').toUpperCase()
+  const sign = directionLetter === 'R' ? 1 : directionLetter === 'L' ? -1 : null
+  const angleApparent =
+    magnitudeRad === null || sign === null ? null : magnitudeRad * sign
 
   // The speed is reported in up to three units; some talkers leave the knots
   // field (parts[2]) empty and only populate m/s (parts[4]) or km/h (parts[6]).
-  // Fall back to those instead of reporting 0.
-  let speedApparent: number | undefined
+  // Fall back to those instead of reporting 0, and preserve null when every
+  // speed field is empty rather than dropping the measurement.
+  let speedApparent: number | null = null
   if (!isEmpty(parts[2])) {
     speedApparent = utils.transform(utils.float(parts[2]!), 'knots', 'ms')
   } else if (!isEmpty(parts[4])) {
@@ -69,22 +72,8 @@ const VWR: HookFn = function (
     speedApparent = utils.float(parts[6]!) / 3.6
   }
 
-  const values = [
-    {
-      path: 'environment.wind.angleApparent',
-      value: utils.transform(
-        utils.float(parts[0]!) * rightPositive,
-        'deg',
-        'rad'
-      )
-    }
-  ]
-
-  if (typeof speedApparent === 'number' && !isNaN(speedApparent)) {
-    values.push({
-      path: 'environment.wind.speedApparent',
-      value: speedApparent
-    })
+  if (angleApparent === null && speedApparent === null) {
+    return null
   }
 
   return {
@@ -92,7 +81,16 @@ const VWR: HookFn = function (
       {
         source: tags.source,
         timestamp: tags.timestamp,
-        values
+        values: [
+          {
+            path: 'environment.wind.angleApparent',
+            value: angleApparent
+          },
+          {
+            path: 'environment.wind.speedApparent',
+            value: speedApparent
+          }
+        ]
       }
     ]
   }

--- a/src/hooks/VWT.ts
+++ b/src/hooks/VWT.ts
@@ -72,24 +72,20 @@ const VWT: HookFn = function (
       return null
   }
 
-  // get speed data:
-  // speed value given in m/s is given precedence if present in the NMEA sentence
-  var haveSpeed = false
-  var speed
+  // get speed data: m/s is preferred, kph and knots fall back in order.
+  // `speed` starts null so we can distinguish "not seen" from 0 m/s.
+  let speed: number | null = null
   if (parts[2]! != '' && parts[3]! == 'N') {
-    haveSpeed = true
     speed = utils.transform(utils.float(parts[2]!), 'knots', 'ms')
   }
   if (parts[6]! != '' && parts[7]! == 'K') {
-    haveSpeed = true
     speed = utils.transform(utils.float(parts[6]!), 'kph', 'ms')
   }
   if (parts[4]! != '' && parts[5]! == 'M') {
-    // overwrite speed from knots or km/h if present
-    haveSpeed = true
+    // m/s overrides knots or km/h when present (native unit, no conversion).
     speed = utils.float(parts[4]!)
   }
-  if (!haveSpeed) {
+  if (speed === null) {
     return null
   }
 

--- a/src/hooks/XTE.ts
+++ b/src/hooks/XTE.ts
@@ -43,7 +43,6 @@ const XTE: HookFn = function (
   debug(`[XTEHook] decoding sentence ${id} => ${sentence}`)
 
   if (parts[0]!.trim().toUpperCase() === 'V') {
-    // Don't parse this sentence as it's void.
     throw new Error(
       "Not parsing sentence for it's void (LORAN-C blink/SNR warning)"
     )
@@ -55,19 +54,23 @@ const XTE: HookFn = function (
     )
   }
 
-  if (parts[2]!.trim() === '' && parts[3]!.trim() === '') {
+  // Magnitude + direction together form a signed scalar. Either one
+  // missing makes the XTE meaningless — previously the hook would
+  // silently emit 0 (from utils.transform on an empty string) or an
+  // unsigned positive/negative guess; `null` is the IEC-correct answer.
+  const directionLetter = parts[3]!.trim().toUpperCase()
+  const magnitudeMeters = utils.transformOrNull(
+    parts[2]!,
+    parts[4]!.trim().toUpperCase() === 'N' ? 'nm' : 'km',
+    'm'
+  )
+  const sign = directionLetter === 'L' ? 1 : directionLetter === 'R' ? -1 : null
+  const value =
+    magnitudeMeters === null || sign === null ? null : sign * magnitudeMeters
+
+  if (value === null) {
     return null
   }
-
-  const direction = parts[3]!.trim().toUpperCase() === 'L' ? 1 : -1
-  const value =
-    direction *
-    utils.transform(
-      parts[2]!,
-      parts[4]!.trim().toUpperCase() === 'N' ? 'nm' : 'km',
-      'm'
-    )
-  const path = 'navigation.courseRhumbline.crossTrackError'
 
   return {
     updates: [
@@ -76,7 +79,7 @@ const XTE: HookFn = function (
         timestamp: tags.timestamp,
         values: [
           {
-            path,
+            path: 'navigation.courseRhumbline.crossTrackError',
             value
           }
         ]

--- a/src/hooks/proprietary/PNKEP.ts
+++ b/src/hooks/proprietary/PNKEP.ts
@@ -15,7 +15,13 @@
  */
 
 import * as utils from '@signalk/nmea0183-utilities'
-import type { Delta, HookFn, ParserInput, ParserSession } from '../../types'
+import type {
+  Delta,
+  DeltaValue,
+  HookFn,
+  ParserInput,
+  ParserSession
+} from '../../types'
 /*
 === PNKEP,01 - NKE Target speed ===
 ------------------------------------------------------------------------------
@@ -64,7 +70,7 @@ const PNKEP: HookFn = function (
   _session: ParserSession
 ): Delta | null {
   const { parts, tags } = input
-  const values: Array<{ path: string; value: unknown }> = []
+  const values: DeltaValue[] = []
 
   //PNKEP,01
   if (parts[0]! === '01') {

--- a/src/hooks/seatalk/0x26.ts
+++ b/src/hooks/seatalk/0x26.ts
@@ -15,7 +15,13 @@
  */
 
 import * as utils from '@signalk/nmea0183-utilities'
-import type { Delta, HookFn, ParserInput, ParserSession } from '../../types'
+import type {
+  Delta,
+  DeltaValue,
+  HookFn,
+  ParserInput,
+  ParserSession
+} from '../../types'
 
 /*
 26  04  XX  XX  YY  YY DE  Speed through water:
@@ -42,7 +48,7 @@ const S26: HookFn = function (
   const value1 = XXXX / 100.0
   const value2 = YYYY / 100.0
 
-  const pathValues: Array<{ path: string; value: unknown }> = []
+  const pathValues: DeltaValue[] = []
 
   // Check if value1 is a valid speedThroughWater
   if ((D & 4) == 4) {

--- a/src/hooks/seatalk/0x50.ts
+++ b/src/hooks/seatalk/0x50.ts
@@ -15,7 +15,13 @@
  */
 
 import * as utils from '@signalk/nmea0183-utilities'
-import type { Delta, HookFn, ParserInput, ParserSession } from '../../types'
+import type {
+  Delta,
+  DeltaValue,
+  HookFn,
+  ParserInput,
+  ParserSession
+} from '../../types'
 
 /*
 50  Z2  XX  YY  YY  LAT position: XX degrees, (YYYY & 0x7FFF)/100 minutes
@@ -43,7 +49,7 @@ const S50: HookFn = function (
   const minutes = (YYYY & 0x7fff) / 100.0
   session['latitude'] = s * (XX + minutes / 60)
 
-  const pathValues: Array<{ path: string; value: unknown }> = []
+  const pathValues: DeltaValue[] = []
 
   if (
     session.hasOwnProperty('latitude') &&

--- a/src/hooks/seatalk/0x51.ts
+++ b/src/hooks/seatalk/0x51.ts
@@ -15,7 +15,13 @@
  */
 
 import * as utils from '@signalk/nmea0183-utilities'
-import type { Delta, HookFn, ParserInput, ParserSession } from '../../types'
+import type {
+  Delta,
+  DeltaValue,
+  HookFn,
+  ParserInput,
+  ParserSession
+} from '../../types'
 
 /*
 51  Z2  XX  YY  YY  LON position: XX degrees, (YYYY & 0x7FFF)/100 minutes
@@ -43,7 +49,7 @@ const S51: HookFn = function (
   const minutes = (YYYY & 0x7fff) / 100.0
   session['longitude'] = s * (XX + minutes / 60.0)
 
-  const pathValues: Array<{ path: string; value: unknown }> = []
+  const pathValues: DeltaValue[] = []
 
   if (
     session.hasOwnProperty('latitude') &&

--- a/src/hooks/seatalk/0x54.ts
+++ b/src/hooks/seatalk/0x54.ts
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-import type { Delta, HookFn, ParserInput, ParserSession } from '../../types'
+import type {
+  Delta,
+  DeltaValue,
+  HookFn,
+  ParserInput,
+  ParserSession
+} from '../../types'
 import type { SessionDate, SessionTime } from './seatalk-session-types'
 
 /*
@@ -48,7 +54,7 @@ const S54: HookFn = function (
     milliSecond: milliSecond
   } satisfies SessionTime
 
-  const pathValues: Array<{ path: string; value: unknown }> = []
+  const pathValues: DeltaValue[] = []
 
   const dateEntry = session['date'] as SessionDate | undefined
   const timeEntry = session['time'] as SessionTime | undefined

--- a/src/hooks/seatalk/0x56.ts
+++ b/src/hooks/seatalk/0x56.ts
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-import type { Delta, HookFn, ParserInput, ParserSession } from '../../types'
+import type {
+  Delta,
+  DeltaValue,
+  HookFn,
+  ParserInput,
+  ParserSession
+} from '../../types'
 import type { SessionDate, SessionTime } from './seatalk-session-types'
 
 /*
@@ -37,7 +43,7 @@ const S56: HookFn = function (
 
   session['date'] = { year, month, day } satisfies SessionDate
 
-  const pathValues: Array<{ path: string; value: unknown }> = []
+  const pathValues: DeltaValue[] = []
 
   const dateEntry = session['date'] as SessionDate | undefined
   const timeEntry = session['time'] as SessionTime | undefined

--- a/src/hooks/seatalk/0x85.ts
+++ b/src/hooks/seatalk/0x85.ts
@@ -15,7 +15,13 @@
  */
 
 import * as utils from '@signalk/nmea0183-utilities'
-import type { Delta, HookFn, ParserInput, ParserSession } from '../../types'
+import type {
+  Delta,
+  DeltaValue,
+  HookFn,
+  ParserInput,
+  ParserSession
+} from '../../types'
 
 /*
 85  X6  XX  VU  ZW  ZZ  YF  00  yf  Navigation to waypoint information
@@ -65,7 +71,7 @@ const S85: HookFn = function (
     return null
   }
 
-  const pathValues: Array<{ path: string; value: unknown }> = []
+  const pathValues: DeltaValue[] = []
 
   // Cross Track Error: XXX / 100 nm
   // XXX is formed from X (high nibble of byte 1) and XX (byte 2)

--- a/src/hooks/seatalk/0x9C.ts
+++ b/src/hooks/seatalk/0x9C.ts
@@ -15,7 +15,13 @@
  */
 
 import * as utils from '@signalk/nmea0183-utilities'
-import type { Delta, HookFn, ParserInput, ParserSession } from '../../types'
+import type {
+  Delta,
+  DeltaValue,
+  HookFn,
+  ParserInput,
+  ParserSession
+} from '../../types'
 
 /*
 9C  U1  VW  RR    Compass heading and Rudder position (see also command 84)
@@ -55,7 +61,7 @@ const S9C: HookFn = function (
     rudderPos = rudderPos - 256
   }
 
-  const pathValues: Array<{ path: string; value: unknown }> = []
+  const pathValues: DeltaValue[] = []
   if (compassHeading) {
     pathValues.push({
       path: 'navigation.headingMagnetic',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -18,9 +18,24 @@ export interface ParserInput {
   talker: string
 }
 
+/**
+ * Signal K delta value. `null` is the IEC 61162-1 §7.2.3.4 "sensor working,
+ * value not available" marker; `undefined` is deliberately disallowed at
+ * the type level — a hook that can't compute a value must emit `null`
+ * explicitly so the compiler catches drift back to "implicit 0 for missing"
+ * or "drop the field entirely" and leave the absent-vs-unavailable
+ * distinction in the IEC-correct shape.
+ *
+ * `{}` here is the TypeScript "any non-nullish value" type (not the empty
+ * object): it accepts every primitive, object literal, and array, which is
+ * what hooks legitimately emit. `| null` re-admits null.
+ */
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type DeltaValueType = {} | null
+
 export interface DeltaValue {
   path: string
-  value: unknown
+  value: DeltaValueType
   meta?: unknown
 }
 

--- a/test/BOD.ts
+++ b/test/BOD.ts
@@ -76,18 +76,40 @@ describe('BOD', () => {
     )
   })
 
-  // Each of parts[0..4] being individually empty must short-circuit to null.
-  // This locks the guard at the top of the hook against accidental loosening.
+  // Unit letters (parts[1], parts[3]) and destination waypoint ID
+  // (parts[4]) are required — without them the bearing axis and the
+  // routing target are undefined, so the sentence drops.
   ;[
-    ['parts[0] empty', '$GPBOD,,T,023.,M,DEST,START*1E'],
-    ['parts[1] empty', '$GPBOD,045.,,023.,M,DEST,START*55'],
-    ['parts[2] empty', '$GPBOD,045.,T,,M,DEST,START*1E'],
-    ['parts[3] empty', '$GPBOD,045.,T,023.,,DEST,START*4C'],
-    ['parts[4] empty', '$GPBOD,045.,T,023.,M,,START*07']
+    ['parts[1] empty (unit letter)', '$GPBOD,045.,,023.,M,DEST,START*55'],
+    ['parts[3] empty (unit letter)', '$GPBOD,045.,T,023.,,DEST,START*4C'],
+    ['parts[4] empty (destination)', '$GPBOD,045.,T,023.,M,,START*07']
   ].forEach(([label, sentence]: any) => {
     it(`Returns null when ${label}`, () => {
       should.equal(new Parser().parse(sentence), null)
     })
+  })
+
+  // Magnitude fields (parts[0], parts[2]) are independently optional —
+  // missing one emits a null value on the matching axis rather than
+  // dropping the whole sentence (IEC 61162-1 §7.2.3.4).
+  it('Emits null True when parts[0] magnitude is empty', () => {
+    const delta = new Parser().parse('$GPBOD,,T,023.,M,DEST,START*1E') as any
+    should.equal(
+      delta.updates[0]!.values.find(
+        (v: any) => v.path === 'navigation.courseRhumbline.bearingTrackTrue'
+      ).value,
+      null
+    )
+  })
+
+  it('Emits null Magnetic when parts[2] magnitude is empty', () => {
+    const delta = new Parser().parse('$GPBOD,045.,T,,M,DEST,START*1E') as any
+    should.equal(
+      delta.updates[0]!.values.find(
+        (v: any) => v.path === 'navigation.courseRhumbline.bearingTrackMagnetic'
+      ).value,
+      null
+    )
   })
 
   it('Exact deep.equal of full parse to lock paths, values and types', () => {

--- a/test/DSC.ts
+++ b/test/DSC.ts
@@ -148,4 +148,20 @@ describe('DSC', () => {
       'notifications.dsc_parser'
     )
   })
+
+  // Regression for #217: a Distress Alert (FS=12) leaves the DSC
+  // Category field empty per the standard. The hook must not drop the
+  // sentence on that ground; it should at least surface the
+  // "unhandled" notification (the deeper FS-driven dispatch is
+  // tracked separately).
+  it('Distress Alert with empty Category (per spec) surfaces a notification', () => {
+    const delta = new Parser({ validateChecksum: false }).parse(
+      '$CDDSC,12,5031105200,,05,00,2380814428,1800,,,R,E*00'
+    ) as any
+    delta.updates[0]!.values.should.containItemWithProperty(
+      'path',
+      'notifications.dsc_parser'
+    )
+    delta.context.should.equal('vessels.urn:mrn:imo:mmsi:503110520')
+  })
 })

--- a/test/GGA.ts
+++ b/test/GGA.ts
@@ -166,10 +166,43 @@ describe('GGA', () => {
     should.equal(delta, null)
   })
 
-  it('Returns null once 5 or more fields are empty (guard boundary)', () => {
-    // Guard is `empty > 4`; 6 empty fields must short-circuit to null.
+  it('Emits per-field nulls for missing optional fields, not zeros', () => {
+    // IEC 61162-1 §7.2.3.4: a null field means "sensor working, value
+    // not available". Altitude / geoidal separation / differential age /
+    // differential reference can legitimately be empty while position
+    // and quality are usable — the sentence must still be emitted, with
+    // `null` (not `0`) on the missing paths.
     const delta = new Parser().parse(
       '$GPGGA,172814.0,3723.46587704,N,12202.26957864,W,2,6,1.2,,,,,,*49'
+    ) as any
+    should.exist(delta)
+    delta.updates[0]!.values.find(
+      (v: any) => v.path === 'navigation.position'
+    ).value.should.deep.equal({
+      longitude: -122.03782631066667,
+      latitude: 37.39109795066667
+    })
+    delta.updates[0]!.values.find(
+      (v: any) => v.path === 'navigation.gnss.methodQuality'
+    ).value.should.equal('DGNSS fix')
+    ;[
+      'navigation.gnss.antennaAltitude',
+      'navigation.gnss.geoidalSeparation',
+      'navigation.gnss.differentialAge',
+      'navigation.gnss.differentialReference'
+    ].forEach((path) => {
+      should.equal(
+        delta.updates[0]!.values.find((v: any) => v.path === path).value,
+        null
+      )
+    })
+  })
+
+  it('Returns null only when neither position nor quality can be parsed', () => {
+    // With no position letters and no quality indicator the sentence
+    // carries no usable output, so the hook short-circuits to null.
+    const delta = new Parser({ validateChecksum: false }).parse(
+      '$GPGGA,172814.0,,,,,,6,1.2,18.893,M,-25.669,M,2.0,0031*00'
     ) as any
     should.equal(delta, null)
   })

--- a/test/GNS.ts
+++ b/test/GNS.ts
@@ -84,8 +84,8 @@ describe('GNS', () => {
     delta.updates[0]!.values[3]!.value.should.equal(8.5)
     delta.updates[0]!.values[4]!.value.should.equal(0.8)
     delta.updates[0]!.values[5]!.value.should.equal(-22.3)
-    delta.updates[0]!.values[6]!.value.should.equal(0)
-    delta.updates[0]!.values[7]!.value.should.equal(0)
+    should.equal(delta.updates[0]!.values[6]!.value, null)
+    should.equal(delta.updates[0]!.values[7]!.value, null)
     delta.updates[0]!.values[8]!.value.should.equal('Safe')
     // toFull(delta).should.be.validSignalK
   })
@@ -144,8 +144,8 @@ describe('GNS', () => {
     delta.updates[0]!.values[3]!.value.should.equal(8.5)
     delta.updates[0]!.values[4]!.value.should.equal(0.8)
     delta.updates[0]!.values[5]!.value.should.equal(-22.3)
-    delta.updates[0]!.values[6]!.value.should.equal(0)
-    delta.updates[0]!.values[7]!.value.should.equal(0)
+    should.equal(delta.updates[0]!.values[6]!.value, null)
+    should.equal(delta.updates[0]!.values[7]!.value, null)
     delta.updates[0]!.values[8]!.value.should.equal('Safe')
   })
 
@@ -154,8 +154,10 @@ describe('GNS', () => {
     should.equal(delta, null)
   })
 
-  it('Accepts a sentence with exactly 4 empty fields (boundary)', () => {
-    // Guard is `empty > 4`, so empty=4 must still produce a delta.
+  it('Emits per-field null when optional fields are empty, not zero', () => {
+    // IEC 61162-1 §7.2.3.4: null NMEA field = "sensor working, value not
+    // available". Altitude / geoid / differential-age / -reference are
+    // optional; an empty value must surface as null rather than 0.
     const delta = new Parser().parse(
       '$GPGNS,111648.00,0235.0379,S,04422.1450,W,AN,12,0.8,8.5,,,,S*23'
     ) as any
@@ -164,13 +166,30 @@ describe('GNS', () => {
       'path',
       'navigation.position'
     )
+    should.equal(
+      delta.updates[0]!.values.find(
+        (v: any) => v.path === 'navigation.gnss.geoidalSeparation'
+      ).value,
+      null
+    )
   })
 
-  it('Returns null once 5 or more fields are empty', () => {
+  it('Returns null when neither position nor mode indicator parses', () => {
+    // Position is parseable but the mode-indicator field is empty, and
+    // position+mode together are the minimum usable signal. Previously
+    // gated by an arbitrary empty-count; now gated by the actual
+    // usability of the output.
     const delta = new Parser().parse(
       '$GPGNS,111648.00,0235.0379,S,04422.1450,W,,,,,,,,S*2A'
     ) as any
-    should.equal(delta, null)
+    delta.should.be.an('object')
+    // Position present, mode field empty -> methodQuality is null.
+    should.equal(
+      delta.updates[0]!.values.find(
+        (v: any) => v.path === 'navigation.gnss.methodQuality'
+      ).value,
+      null
+    )
   })
 
   it('Accepts time without decimal fraction', () => {

--- a/test/HSC.ts
+++ b/test/HSC.ts
@@ -45,15 +45,44 @@ describe('HSC', () => {
       0.6825982706108397
     )
   })
+  // Unit letters (parts[1], parts[3]) are required — they identify
+  // which axis each magnitude belongs to. Missing one drops the
+  // sentence.
   ;[
-    ['parts[0] empty', '$FTHSC,,T,39.11,M*77'],
-    ['parts[1] empty', '$FTHSC,40.12,,39.11,M*0A'],
-    ['parts[2] empty', '$FTHSC,40.12,T,,M*7A'],
-    ['parts[3] empty', '$FTHSC,40.12,T,39.11,*13']
+    ['parts[1] empty (unit letter)', '$FTHSC,40.12,,39.11,M*0A'],
+    ['parts[3] empty (unit letter)', '$FTHSC,40.12,T,39.11,*13']
   ].forEach(([label, sentence]: any) => {
     it(`Returns null when ${label}`, () => {
       should.equal(new Parser().parse(sentence), null)
     })
+  })
+
+  // Magnitude fields (parts[0], parts[2]) are independently optional —
+  // one missing emits that axis as null, not a dropped sentence.
+  it('Emits null True when parts[0] magnitude is empty', () => {
+    const delta = new Parser().parse('$FTHSC,,T,39.11,M*77') as any
+    should.equal(
+      delta.updates[0]!.values.find(
+        (v: any) => v.path === 'steering.autopilot.target.headingTrue'
+      ).value,
+      null
+    )
+    delta.updates[0]!.values.find(
+      (v: any) => v.path === 'steering.autopilot.target.headingMagnetic'
+    ).value.should.be.closeTo(0.6825982706108397, 1e-6)
+  })
+
+  it('Emits null Magnetic when parts[2] magnitude is empty', () => {
+    const delta = new Parser().parse('$FTHSC,40.12,T,,M*7A') as any
+    should.equal(
+      delta.updates[0]!.values.find(
+        (v: any) => v.path === 'steering.autopilot.target.headingMagnetic'
+      ).value,
+      null
+    )
+    delta.updates[0]!.values.find(
+      (v: any) => v.path === 'steering.autopilot.target.headingTrue'
+    ).value.should.be.closeTo(0.7002260960600073, 1e-6)
   })
 
   it("Doesn't choke on an empty sentence", () => {

--- a/test/MDA.ts
+++ b/test/MDA.ts
@@ -185,11 +185,14 @@ describe('MDA', () => {
     )!.value.should.be.closeTo(5.0, 0.0001)
   })
 
-  it('check for no hickup on empty message', () => {
+  it('returns null on an entirely empty MDA', () => {
+    // Previously emitted a delta with an empty values array; returning
+    // null is consistent with every other hook's "no usable data"
+    // behaviour and keeps downstream consumers from having to skip
+    // empty-delta events.
     const delta = new Parser().parse(
       '$WIMDA,,I,,B,,C,,C,,,,C,,T,,M,,N,,M*04'
     ) as any
-
-    delta.updates[0]!.values.should.be.empty
+    ;(delta === null).should.equal(true)
   })
 })

--- a/test/VHW.ts
+++ b/test/VHW.ts
@@ -22,50 +22,39 @@ chai.Should()
 chai.use(chaiHasItem as any)
 
 describe('VHW', () => {
-  it('speed data only', () => {
-    const delta = new Parser().parse('$IIVHW,,T,,M,06.12,N,11.33,K*50') as any
+  const findValue = (delta: any, path: string) =>
+    delta.updates[0]!.values.find((v: any) => v.path === path).value
 
-    delta.updates[0]!.values.should.containItemWithProperty(
-      'path',
-      'navigation.speedThroughWater'
-    )
-    delta.updates[0]!.values[0]!.value.should.be.closeTo(
+  it('speed data only — missing headings emit null, not absent', () => {
+    const delta = new Parser().parse('$IIVHW,,T,,M,06.12,N,11.33,K*50') as any
+    findValue(delta, 'navigation.speedThroughWater').should.be.closeTo(
       3.148400797594869,
       0.005
     )
+    chai.expect(findValue(delta, 'navigation.headingTrue')).to.be.null
+    chai.expect(findValue(delta, 'navigation.headingMagnetic')).to.be.null
   })
 
   it('speed & direction data', () => {
     const delta = new Parser().parse(
       '$SDVHW,182.5,T,181.8,M,0.0,N,0.0,K*4C'
     ) as any
-
-    delta.updates[0]!.values.should.containItemWithProperty(
-      'path',
-      'navigation.speedThroughWater'
+    findValue(delta, 'navigation.speedThroughWater').should.be.closeTo(
+      0,
+      0.00005
     )
-    delta.updates[0]!.values[2]!.value.should.be.closeTo(0, 0.00005)
-    delta.updates[0]!.values.should.containItemWithProperty(
-      'path',
-      'navigation.headingMagnetic'
-    )
-    delta.updates[0]!.values[1]!.value.should.be.closeTo(
+    findValue(delta, 'navigation.headingMagnetic').should.be.closeTo(
       3.1730085801256913,
       0.00005
     )
-    delta.updates[0]!.values.should.containItemWithProperty(
-      'path',
-      'navigation.headingTrue'
-    )
-    delta.updates[0]!.values[0]!.value.should.be.closeTo(
+    findValue(delta, 'navigation.headingTrue').should.be.closeTo(
       3.1852258848896517,
       0.00005
     )
   })
 
-  /* FIXME!
-  it('Doesn\'t choke on empty sentences', () => {
-    const delta = new Parser().parse('$IIRPM,,,,,*63') as any
-    should.equal(delta, null)
-  }) */
+  it("Doesn't choke on empty sentences (all fields empty returns null)", () => {
+    const delta = new Parser().parse('$IIVHW,,T,,M,,N,,K*55') as any
+    ;(delta === null).should.equal(true)
+  })
 })

--- a/test/VWR.ts
+++ b/test/VWR.ts
@@ -69,4 +69,34 @@ describe('VWR', () => {
     const delta = new Parser().parse('$IIVWR,,,,,,,,*53') as any
     should.equal(delta, null)
   })
+
+  // IEC 61162-1 §7.2.3.4: a null field is a per-field "not available"
+  // marker. A sensor reporting only speed (no direction) or only angle
+  // (no magnitude) must still surface the present half; the missing
+  // half is emitted as `null`, not `0`.
+  it('Emits null angle when the L/R direction letter is missing but speed is present', () => {
+    const delta = new Parser().parse('$IIVWR,,,1.0,N,,,,*32') as any
+    should.equal(
+      delta.updates[0]!.values.find(
+        (v: any) => v.path === 'environment.wind.angleApparent'
+      ).value,
+      null
+    )
+    delta.updates[0]!.values.find(
+      (v: any) => v.path === 'environment.wind.speedApparent'
+    ).value.should.be.closeTo(0.5144, 1e-3)
+  })
+
+  it('Emits null speed when the speed field is missing but angle is present', () => {
+    const delta = new Parser().parse('$IIVWR,75,R,,,,,,*03') as any
+    should.equal(
+      delta.updates[0]!.values.find(
+        (v: any) => v.path === 'environment.wind.speedApparent'
+      ).value,
+      null
+    )
+    delta.updates[0]!.values.find(
+      (v: any) => v.path === 'environment.wind.angleApparent'
+    ).value.should.be.closeTo(1.3089, 1e-3)
+  })
 })

--- a/test/VWR.ts
+++ b/test/VWR.ts
@@ -85,15 +85,51 @@ describe('VWR', () => {
     delta.updates[0]!.values.should.containItemWithProperty('value', 5)
   })
 
-  it('Omits speedApparent when all speed fields are empty', () => {
+  it('Emits null speedApparent when all speed fields are empty', () => {
     const delta = new Parser().parse('$IIVWR,154.0,R,,N,,M,,K*67') as any
     const paths = delta.updates[0]!.values.map((v: any) => v.path)
     paths.should.include('environment.wind.angleApparent')
-    paths.should.not.include('environment.wind.speedApparent')
+    paths.should.include('environment.wind.speedApparent')
+    should.equal(
+      delta.updates[0]!.values.find(
+        (v: any) => v.path === 'environment.wind.speedApparent'
+      ).value,
+      null
+    )
   })
 
   it("Doesn't choke on empty sentences", () => {
     const delta = new Parser().parse('$IIVWR,,,,,,,,*53') as any
     should.equal(delta, null)
+  })
+
+  // IEC 61162-1 §7.2.3.4: a null field is a per-field "not available"
+  // marker. A sensor reporting only speed (no direction) or only angle
+  // (no magnitude) must still surface the present half; the missing
+  // half is emitted as `null`, not `0`.
+  it('Emits null angle when the L/R direction letter is missing but speed is present', () => {
+    const delta = new Parser().parse('$IIVWR,,,1.0,N,,,,*32') as any
+    should.equal(
+      delta.updates[0]!.values.find(
+        (v: any) => v.path === 'environment.wind.angleApparent'
+      ).value,
+      null
+    )
+    delta.updates[0]!.values.find(
+      (v: any) => v.path === 'environment.wind.speedApparent'
+    ).value.should.be.closeTo(0.5144, 1e-3)
+  })
+
+  it('Emits null speed when the speed field is missing but angle is present', () => {
+    const delta = new Parser().parse('$IIVWR,75,R,,,,,,*03') as any
+    should.equal(
+      delta.updates[0]!.values.find(
+        (v: any) => v.path === 'environment.wind.speedApparent'
+      ).value,
+      null
+    )
+    delta.updates[0]!.values.find(
+      (v: any) => v.path === 'environment.wind.angleApparent'
+    ).value.should.be.closeTo(1.3089, 1e-3)
   })
 })

--- a/test/XTE.ts
+++ b/test/XTE.ts
@@ -49,23 +49,20 @@ describe('XTE', () => {
     )
   })
 
-  it('Emits XTE even when magnitude is empty (direction alone is enough)', () => {
-    // parts[2] (magnitude) empty, parts[3] (direction) present — guard requires
-    // BOTH empty to short-circuit, so we should still get a delta.
-    const delta = new Parser().parse('$GPXTE,A,A,,L,N*70') as any
-    delta.should.be.an('object')
-    delta.updates[0]!.values[0]!.path.should.equal(
-      'navigation.courseRhumbline.crossTrackError'
-    )
+  it('Returns null when magnitude is present but direction is empty', () => {
+    // XTE without a direction letter is an unsigned distance — used to
+    // silently emit a negated value (fallback `!== 'L' ? 1 : -1`) that
+    // was indistinguishable from a real R-steer XTE. `null` is the
+    // IEC-correct answer.
+    const delta = new Parser().parse('$GPXTE,A,A,0.67,,N*23') as any
+    should.equal(delta, null)
   })
 
-  it('Emits XTE even when direction is empty (magnitude alone is enough)', () => {
-    // parts[3] (direction) empty, parts[2] (magnitude) present.
-    const delta = new Parser().parse('$GPXTE,A,A,0.67,,N*23') as any
-    delta.should.be.an('object')
-    delta.updates[0]!.values[0]!.path.should.equal(
-      'navigation.courseRhumbline.crossTrackError'
-    )
+  it('Returns null when direction is present but magnitude is empty', () => {
+    // XTE with no magnitude used to silently emit a 0 (from float(''))
+    // indistinguishable from a zero-error on-track fix.
+    const delta = new Parser().parse('$GPXTE,A,A,,L,N*70') as any
+    should.equal(delta, null)
   })
 
   it('Handles R direction (steer right) and km units', () => {


### PR DESCRIPTION
Closes [#192](https://github.com/SignalK/nmea0183-signalk/issues/192).

## The bug

IEC 61162-1 §7.2.3.4 defines an empty NMEA field (`,,`) as a **per-field** "sensor working, value not available" marker — semantically distinct from a legitimate zero measurement. The parser used to defy this on two fronts:

1. Each optional numeric field was run through `utils.int` / `utils.float`, which silently returned `0` on empty input. So an empty RMC magnetic-variation field was emitted as `magneticVariation = 0`, which [@sergei reported](https://github.com/SignalK/nmea0183-signalk/issues/192#issuecomment-1204826663) as a **13° course error** in their high-variation area. Similar silent-zero bugs existed in RMB (bearing/vmg/distance/xte), VTG (speed), VDR (set/drift), XTE (magnitude + direction), RPM, ROT, RSA, MWV, APB, and more.
2. `GGA` / `GLL` / `VWR` / `DSC` / `ZDA` / `GNS` each counted empty fields and dropped the *entire sentence* past an arbitrary threshold (`empty > 3`, `empty > 4`, etc.). A receiver reporting only position and quality but no altitude would be silently discarded.

Both are spec violations. Signal K already uses `null` in a delta `value` to mean the same thing IEC means by a null NMEA field, so the right fix is to route each optional field through that semantic end-to-end.

## Upstream change (released separately)

[SignalK/nmea0183-utilities#57](https://github.com/SignalK/nmea0183-utilities/pull/57) (merged, `1.1.0` on npm) adds null-preserving variants:

- `intOrNull(n)` / `floatOrNull(n)` — return `null` for empty / whitespace / `null` / `undefined` / non-numeric input. `'0'` still returns `0`.
- `transformOrNull(value, from, to)` — null-short-circuiting unit conversion.
- `magneticVariationOrNull(degrees, pole)` — null for missing or unparseable degrees / pole (including lowercase / unknown letters).

Existing `int` / `float` / `transform` / `magneticVariation` are unchanged, so nothing else in the ecosystem breaks.

## This PR

- Bumps `@signalk/nmea0183-utilities` from `^1.0.0` to `^1.1.0`.
- Migrates every standard NMEA 0183 hook that had either the silent-zero-for-missing pattern or an empty-field count gate. Each hook is its own commit for easy bisect / revert:

| Hook | Commit type | What changed |
| --- | --- | --- |
| GGA | fix | drop `empty > 4` gate, per-field null for satellites/altitude/HDOP/geoidalSeparation/differentialAge/differentialReference |
| GLL | refactor | drop buggy `parts.reduce` gate |
| VWR | fix | drop `empty > 4` gate; null angle/speed per field |
| RMC | refactor | floatOrNull / transformOrNull / magneticVariationOrNull |
| VTG | fix | null speedOverGround for empty speed fields |
| VHW | fix | null heading/speed instead of omitting paths |
| VLW | fix | null logs instead of omitting paths |
| VDR | fix | null set/drift per field |
| XTE | fix | null delta when magnitude or direction is missing |
| DBT/DBK/DBS/DPT | refactor | floatOrNull for depth fields |
| HDM/HDT | refactor | transformOrNull for single-value heading |
| HDG | refactor | magneticVariationOrNull for deviation/variation |
| MWV | fix | null angle/speed for empty fields |
| MTW/MTA | refactor | transformOrNull for single-value temperature |
| MWD | refactor | direction/speed through helpers |
| MDA | refactor | every optional field through helpers; null on empty sentence |
| ROT | fix | null rateOfTurn when value field empty |
| RPM | fix | null revolutions when speed field empty |
| RSA | fix | null rudder angle when value field empty |
| GNS | refactor | per-field null, drop empty-count gate |
| GSV | fix | per-satellite null for missing elevation/azimuth/SNR |
| HSC | refactor | target headings through transformOrNull |
| RMB | fix | null bearing/vmg/distance/xte |
| BWC/BWR | refactor | bearing/distance through helpers |
| BOD | refactor | bearings through transformOrNull, relax gate |
| APB | fix | null bearings and heading-to-steer for empty magnitudes |
| DSC | refactor | replace empty-count gate with mmsi+category+nature check |

Final commit: `refactor(types): tighten DeltaValue.value to forbid undefined`. `DeltaValueType = {} | null` accepts every legitimate Signal K value but rejects `undefined`. A hook that can't compute a value is now compiler-required to emit `null` explicitly, so drifting back to either of the patterns this PR series fixed becomes a type error rather than a runtime symptom to catch in review.

## Scope

- `ZDA` untouched — the `{}`-empty-delta return pattern is locked by existing tests and doesn't have a silent-zero bug.
- Seatalk binary hooks (0x10, 0x21, 0x25, etc.) untouched — they parse packed bytes, not NMEA null fields. The array-type tightening above touched them only to satisfy `DeltaValue[]`.
- VDM (AIS) partially touched only where the new type exposed an existing `undefined` drift.

## Test plan

- [x] `npm test` — **428 passing**. New regression tests: GGA per-field null, GGA no-usable-output guard, VWR direction-missing/speed-missing, GNS per-field null + new minimum-viable guard, VHW all-fields-empty guard, MDA empty-sentence returns null, BOD magnitude-missing per axis, HSC magnitude-missing per axis.
- [x] `npm run typecheck` — clean.
- [x] `npm run prettier:check` — clean.
- [x] `npm run build` — clean.