### PR TITLE
refactor: use @signalk/server-api types in custom-sentence-plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "nmea0183-signalk": "dist/bin/nmea0183-signalk.js"
       },
       "devDependencies": {
+        "@signalk/server-api": "^2.24.0",
         "@stryker-mutator/core": "^9.6.1",
         "@stryker-mutator/mocha-runner": "^9.6.1",
         "@types/chai": "^5.2.3",
@@ -1454,6 +1455,19 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@js-temporal/polyfill": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.5.1.tgz",
+      "integrity": "sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "jsbi": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@jsdevtools/ono": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
@@ -1487,6 +1501,18 @@
         "node": ">=22"
       }
     },
+    "node_modules/@signalk/server-api": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/@signalk/server-api/-/server-api-2.24.0.tgz",
+      "integrity": "sha512-IZWVIuV/vOG4obKZ7vhUCfZ19XhpmXlUq8MNV9G10S6vF2vBKZ6JiOaYVVAyzbihlzPafD4Mq7wGurvWur1a0g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@js-temporal/polyfill": "^0.5.1",
+        "@sinclair/typebox": "^0.34.0",
+        "baconjs": "^3.0.0"
+      }
+    },
     "node_modules/@signalk/signalk-schema": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/@signalk/signalk-schema/-/signalk-schema-1.8.2.tgz",
@@ -1506,6 +1532,13 @@
       "funding": {
         "url": "https://opencollective.com/signalk"
       }
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "4.0.0",
@@ -1760,6 +1793,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/baconjs": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/baconjs/-/baconjs-3.0.23.tgz",
+      "integrity": "sha512-Yzm9KTwEw9DhXuE47We0kwhBOkMa5BH2vrOQ8A/SGr8uAH3lDCbTSr0iU0G5irkRQDW/v+jDSMP77geV99U9dw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
@@ -2899,6 +2939,13 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/jsbi": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.2.tgz",
+      "integrity": "sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/jsesc": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "split": "^1.0.1"
   },
   "devDependencies": {
+    "@signalk/server-api": "^2.24.0",
     "@stryker-mutator/core": "^9.6.1",
     "@stryker-mutator/mocha-runner": "^9.6.1",
     "@types/chai": "^5.2.3",

--- a/src/custom-sentence-plugin/index.ts
+++ b/src/custom-sentence-plugin/index.ts
@@ -7,31 +7,12 @@
  *     echo '$IIXXX,1,2,3,foobar,D*17' | nc -u -w 0 127.0.0.1 7777
  */
 
-import type { HookFn, ParserInput, ParserSession } from '../types'
+import type { Plugin, ServerAPI } from '@signalk/server-api'
+import type { ParserInput, ParserSession } from '../types'
 
-interface SignalKApp {
-  emitPropertyValue: (
-    name: string,
-    value: { sentence: string; parser: HookFn }
-  ) => void
-}
-
-interface PluginSchema {
-  [key: string]: unknown
-}
-
-interface SignalKPlugin {
-  id: string
-  name: string
-  description: string
-  start: () => void
-  stop: () => void
-  schema: PluginSchema
-}
-
-function makePlugin(app: SignalKApp): SignalKPlugin {
+function makePlugin(app: ServerAPI): Plugin {
   const id = 'signalk-nmea0183-custom-sentence-plugin'
-  const plugin: SignalKPlugin = {
+  const plugin: Plugin = {
     id,
     name: id,
     description: id,


### PR DESCRIPTION
## Summary

Replace local `SignalKApp` and `SignalKPlugin` interfaces in `src/custom-sentence-plugin/index.ts` with `ServerAPI` and `Plugin` from `@signalk/server-api`.

The local interfaces were a partial restatement of types already exported by the server-api package. Using the canonical types removes the duplication and means future additions to the server API are picked up automatically.

`@signalk/server-api` is added as a `devDependency` (types-only consumption; runtime instances come from the host server).

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] `npm test` passes (424 tests)
- [x] `npm run prettier:check` passes