### PR TITLE
chore: lower Node floor to >=20.10 for Venus CerboGX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22.x, 24.x]
+        node-version: [20.x, 22.x, 24.x]
 
     steps:
       - name: Checkout

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.19.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@signalk/nmea0183-utilities": "^1.0.0",
+        "@signalk/nmea0183-utilities": "^1.1.1",
         "@signalk/signalk-schema": "^1.7.1",
         "ggencoder": "^1.0.8",
         "split": "^1.0.1"
@@ -35,7 +35,8 @@
         "typescript": "^6.0.3"
       },
       "engines": {
-        "node": ">=22"
+        "//": "Floor at 20.10 to support Venus CerboGX firmware (currently Node 20.18.2). Bump back to >=22 once Cerbo ships a newer Node.",
+        "node": ">=20.10"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
@@ -1493,12 +1494,13 @@
       "license": "MIT"
     },
     "node_modules/@signalk/nmea0183-utilities": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@signalk/nmea0183-utilities/-/nmea0183-utilities-1.1.0.tgz",
-      "integrity": "sha512-akq83MYi/GHRERu+dk3faSrG1I3Av6mqZklObqHkCN1oQddl7ReoyoNrGXI8gglcKU5Nzg7QtKR815W7YfYVqA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@signalk/nmea0183-utilities/-/nmea0183-utilities-1.1.1.tgz",
+      "integrity": "sha512-VzqEc6lMFOCEeXt50IrhkI6CHw/Ejn4Ny3k+PRUiVdE/YiH/8FxIG3J51a2/DnVHskmyEhxYO43jzrKMqfvvIg==",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=22"
+        "//": "Floor at 20.10 to support Venus CerboGX firmware (currently Node 20.18.2). Bump back to >=22 once Cerbo ships a newer Node.",
+        "node": ">=20.10"
       }
     },
     "node_modules/@signalk/server-api": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   },
   "sideEffects": false,
   "engines": {
-    "node": ">=22"
+    "//": "Floor at 20.10 to support Venus CerboGX firmware (currently Node 20.18.2). Bump back to >=22 once Cerbo ships a newer Node.",
+    "node": ">=20.10"
   },
   "files": [
     "dist",
@@ -49,7 +50,7 @@
   "author": "Fabian Tollenaar <fabian@signalk.org> (http://signalk.org)",
   "license": "Apache-2.0",
   "dependencies": {
-    "@signalk/nmea0183-utilities": "^1.0.0",
+    "@signalk/nmea0183-utilities": "^1.1.1",
     "@signalk/signalk-schema": "^1.7.1",
     "ggencoder": "^1.0.8",
     "split": "^1.0.1"


### PR DESCRIPTION
Cerbo GX firmware ships Node 20.18.2 and users can't upgrade. The current `>=22` pin (set during the modernize wave) blocks the plugin from installing under strict-engines installers.

The source uses no Node 22-only APIs — `structuredClone`, `fetch`, `node:test` etc. all exist on 20.10+, and `tsconfig.target` is `ES2022` which Node 20.10 supports fully. Bump is safe.

Changes:
- `engines.node`: `>=22` -> `>=20.10`
- CI matrix: `[22.x, 24.x]` -> `[20.x, 22.x, 24.x]` so a future Node 20 regression is caught
- `//` comment inside the engines block (npm strips `//` at publish) explaining the rationale
- Bump transitive dep `@signalk/nmea0183-utilities` to `^1.1.1` (just published) so its lowered engines floor reaches consumers

**Bump back to `>=22` once Cerbo ships a newer Node.**