### PR TITLE
fix(logo): drop white backdrop so card corners are transparent

### DIFF
--- a/logo.svg
+++ b/logo.svg
@@ -9,8 +9,6 @@
     </clipPath>
   </defs>
 
-  <rect x="0" y="0" width="128" height="128" fill="#fff"/>
-
   <g clip-path="url(#card)">
     <rect width="128" height="128" fill="url(#sea)"/>
 


### PR DESCRIPTION
The logo card has rounded corners via `clipPath`, so the area outside the clip needs to be transparent rather than white. The 128×128 white `<rect>` was a holdover from earlier preview against a white background; on dark UI surfaces it produces visible white triangles around the card.

Single 2-line removal.