### PR TITLE
fix(VWR): fall back to m/s and km/h speed fields

### DIFF
--- a/src/hooks/VWR.ts
+++ b/src/hooks/VWR.ts
@@ -57,25 +57,42 @@ const VWR: HookFn = function (
     rightPositive = -1
   }
 
+  // The speed is reported in up to three units; some talkers leave the knots
+  // field (parts[2]) empty and only populate m/s (parts[4]) or km/h (parts[6]).
+  // Fall back to those instead of reporting 0.
+  let speedApparent: number | undefined
+  if (!isEmpty(parts[2])) {
+    speedApparent = utils.transform(utils.float(parts[2]!), 'knots', 'ms')
+  } else if (!isEmpty(parts[4])) {
+    speedApparent = utils.float(parts[4]!)
+  } else if (!isEmpty(parts[6])) {
+    speedApparent = utils.float(parts[6]!) / 3.6
+  }
+
+  const values = [
+    {
+      path: 'environment.wind.angleApparent',
+      value: utils.transform(
+        utils.float(parts[0]!) * rightPositive,
+        'deg',
+        'rad'
+      )
+    }
+  ]
+
+  if (typeof speedApparent === 'number' && !isNaN(speedApparent)) {
+    values.push({
+      path: 'environment.wind.speedApparent',
+      value: speedApparent
+    })
+  }
+
   return {
     updates: [
       {
         source: tags.source,
         timestamp: tags.timestamp,
-        values: [
-          {
-            path: 'environment.wind.angleApparent',
-            value: utils.transform(
-              utils.float(parts[0]!) * rightPositive,
-              'deg',
-              'rad'
-            )
-          },
-          {
-            path: 'environment.wind.speedApparent',
-            value: utils.transform(utils.float(parts[2]!), 'knots', 'ms')
-          }
-        ]
+        values
       }
     ]
   }

--- a/test/VWR.ts
+++ b/test/VWR.ts
@@ -65,6 +65,33 @@ describe('VWR', () => {
     )
   })
 
+  it('Falls back to m/s when the knots field is empty', () => {
+    const delta = new Parser().parse('$IIVWR,154.0,R,,,7.0,M,,*4B') as any
+
+    delta.updates[0]!.values.should.containItemWithProperty(
+      'path',
+      'environment.wind.speedApparent'
+    )
+    delta.updates[0]!.values.should.containItemWithProperty('value', 7.0)
+  })
+
+  it('Falls back to km/h when knots and m/s are empty', () => {
+    const delta = new Parser().parse('$IIVWR,154.0,R,,,,,18.0,K*73') as any
+
+    delta.updates[0]!.values.should.containItemWithProperty(
+      'path',
+      'environment.wind.speedApparent'
+    )
+    delta.updates[0]!.values.should.containItemWithProperty('value', 5)
+  })
+
+  it('Omits speedApparent when all speed fields are empty', () => {
+    const delta = new Parser().parse('$IIVWR,154.0,R,,N,,M,,K*67') as any
+    const paths = delta.updates[0]!.values.map((v: any) => v.path)
+    paths.should.include('environment.wind.angleApparent')
+    paths.should.not.include('environment.wind.speedApparent')
+  })
+
   it("Doesn't choke on empty sentences", () => {
     const delta = new Parser().parse('$IIVWR,,,,,,,,*53') as any
     should.equal(delta, null)


### PR DESCRIPTION
## Problem

The VWR hook only reads the **knots** field (`parts[2]`) for `environment.wind.speedApparent`, ignoring the **m/s** (`parts[4]`) and **km/h** (`parts[6]`) fields.

The VWR sentence may report wind speed in any of the three units:

```
        0     1   2   3   4    5   6     7  8
$--VWR,x.x,  a,  x.x, N, x.x,  M, x.x,   K*hh
              L/R knots    m/s     km/h
```

Some talkers leave the knots field empty and populate only m/s. A real example from a Brookhouse multiplexer:

```
$IIVWR,154.0,R,,,7.0,M,,*4B
```

Here the actual apparent wind is 7.0 m/s, but since `utils.float('')` returns `0`, the parser reported `environment.wind.speedApparent: 0`. With the device also emitting MWV (which parses correctly) under the same `$source`, the value flickered between the correct speed and 0.

Note this is the mirror of the case already handled in #122, which made VWR accept sentences where fields 4–7 (m/s/km/h) are empty — i.e. knots-only. The knots-empty / m/s-present case was never covered.

## Fix

Fall back **knots → m/s → km/h** for `speedApparent`. When all three speed fields are empty, omit `speedApparent` from the delta entirely rather than reporting a misleading `0`. `angleApparent` is unchanged.

### Behaviour change

A VWR sentence that passes the `empty > 4` guard but has all three speed fields empty (e.g. `$IIVWR,154.0,R,,N,,M,,K`) previously emitted `speedApparent: 0`; it now omits the path. This is the intended correctness improvement (no data vs. a wrong `0`).

## Tests

Added cases for m/s-only, km/h-only, and the all-empty-speed-fields omission. Full suite passes (427 tests), typecheck and prettier clean.