### PR TITLE
Refine DSC position from the $--DSE expansion sentence

### DIFF
--- a/src/hooks/DSC.ts
+++ b/src/hooks/DSC.ts
@@ -16,6 +16,7 @@
  */
 
 import type { Delta, HookFn, ParserInput, ParserSession } from '../types'
+import { rememberDscPosition } from './dscSession'
 import Debug from 'debug'
 const debug = Debug('signalk-parser-nmea0183/DSC')
 function isEmpty(mixed: unknown): boolean {
@@ -61,7 +62,7 @@ function parsePosition(line: string): { longitude: number; latitude: number } {
 
 const DSC: HookFn = function (
   input: ParserInput,
-  _session: ParserSession
+  session: ParserSession
 ): Delta | null {
   const { sentence, parts, tags } = input
   var values: Array<{ path: string; value: unknown }> = []
@@ -166,6 +167,13 @@ const DSC: HookFn = function (
         latitude: position.latitude,
         longitude: position.longitude
       }
+    })
+    // Remember this whole-minute fix so a following $--DSE sentence can refine
+    // it to ten-thousandths of a minute.
+    rememberDscPosition(session, mmsi, {
+      context: 'vessels.urn:mrn:imo:mmsi:' + mmsi,
+      latitude: position.latitude,
+      longitude: position.longitude
     })
   }
   if (distress) {

--- a/src/hooks/DSE.ts
+++ b/src/hooks/DSE.ts
@@ -1,0 +1,86 @@
+import type { Delta, HookFn, ParserInput, ParserSession } from '../types'
+import { recallDscPosition } from './dscSession'
+import Debug from 'debug'
+const debug = Debug('signalk-parser-nmea0183/DSE')
+
+const CODE_ENHANCED_POSITION = '00'
+
+/**
+ * The DSC position is truncated toward zero to whole minutes, so the DSE
+ * fraction always extends the magnitude — applied sign-preserving so the
+ * quadrant is retained.
+ */
+function refine(value: number, minuteFraction: number): number {
+  const sign = value < 0 ? -1 : 1
+  return sign * (Math.abs(value) + minuteFraction / 60)
+}
+
+/*
+ * $--DSE — the expansion sentence that can follow a $--DSC, refining its
+ * position from whole minutes to ten-thousandths of a minute.
+ *
+ *        0 1 2 3          4  5
+ * $--DSE,t,n,A,XXXXXXXXXX,00,llllyyyy*hh
+ *
+ *  0: total sentences in this group
+ *  1: sentence number
+ *  2: query flag ('A' = automatic/unsolicited)
+ *  3: address — MMSI * 10, same convention as $--DSC
+ *  4+: repeated (code, data) pairs; code 00 = enhanced position resolution,
+ *      data = 4 digits latitude + 4 digits longitude, in 1/10000 of a minute
+ */
+const DSE: HookFn = function (
+  input: ParserInput,
+  session: ParserSession
+): Delta | null {
+  const { parts, tags } = input
+
+  // Multi-sentence groups are vanishingly rare on Class-D gear; skip them.
+  if (parts[0] !== '1' || parts[1] !== '1') {
+    return null
+  }
+
+  const mmsi = (parts[3] ?? '').substring(0, 9)
+  if (mmsi.length < 9) {
+    return null
+  }
+
+  const previous = recallDscPosition(session, mmsi)
+  if (!previous) {
+    debug('No preceding DSC position for mmsi ' + mmsi)
+    return null
+  }
+
+  for (let i = 4; i + 1 < parts.length; i += 2) {
+    const data = parts[i + 1] ?? ''
+    if (parts[i] === CODE_ENHANCED_POSITION && /^\d{8}$/.test(data)) {
+      return {
+        updates: [
+          {
+            source: tags.source,
+            timestamp: tags.timestamp,
+            values: [
+              {
+                path: 'navigation.position',
+                value: {
+                  latitude: refine(
+                    previous.latitude,
+                    Number(data.substring(0, 4)) / 10000
+                  ),
+                  longitude: refine(
+                    previous.longitude,
+                    Number(data.substring(4, 8)) / 10000
+                  )
+                }
+              }
+            ]
+          }
+        ],
+        context: previous.context
+      }
+    }
+  }
+  return null
+}
+
+export default DSE

--- a/src/hooks/dscSession.ts
+++ b/src/hooks/dscSession.ts
@@ -1,0 +1,39 @@
+import type { ParserSession } from '../types'
+
+/**
+ * The position reported by a $--DSC sentence, remembered so that a following
+ * $--DSE expansion sentence can refine it. DSE carries only the fractional
+ * minutes of a position, never the absolute coordinates, so it is meaningless
+ * without the preceding DSC fix from the same station.
+ */
+export interface DscPosition {
+  context: string
+  latitude: number
+  longitude: number
+}
+
+const SESSION_KEY = 'dscPositions'
+
+function positions(session: ParserSession): Record<string, DscPosition> {
+  let store = session[SESSION_KEY] as Record<string, DscPosition> | undefined
+  if (!store) {
+    store = {}
+    session[SESSION_KEY] = store
+  }
+  return store
+}
+
+export function rememberDscPosition(
+  session: ParserSession,
+  mmsi: string,
+  position: DscPosition
+): void {
+  positions(session)[mmsi] = position
+}
+
+export function recallDscPosition(
+  session: ParserSession,
+  mmsi: string
+): DscPosition | undefined {
+  return positions(session)[mmsi]
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -16,6 +16,7 @@ import DBK from './DBK'
 import DBS from './DBS'
 import DPT from './DPT'
 import DSC from './DSC'
+import DSE from './DSE'
 import GNS from './GNS'
 import GGA from './GGA'
 import GLL from './GLL'
@@ -60,6 +61,7 @@ const hooks: Record<string, HookFn> = {
   DBS,
   DPT,
   DSC,
+  DSE,
   GNS,
   GGA,
   GLL,

--- a/test/DSE.ts
+++ b/test/DSE.ts
@@ -1,0 +1,47 @@
+import Parser from '../src/lib'
+import * as chai from 'chai'
+import chaiHasItem from './helpers/chai-has-item'
+const should = chai.Should()
+chai.use(chaiHasItem as any)
+
+// A distress alert followed by its position-expansion sentence. The DSC
+// position is accurate only to the whole minute; the DSE refines it to
+// ten-thousandths of a minute.
+const dscDistress = '$CDDSC,12,3380400790,12,06,00,1423108312,2019,,,S,E*6A'
+const dseExpansion = '$CDDSE,1,1,A,3380400790,00,45894494*1B'
+
+describe('DSE', () => {
+  it('refines the position of the preceding DSC sentence', () => {
+    const parser = new Parser()
+    const dsc = parser.parse(dscDistress) as any
+    const coarse = dsc.updates[0]!.values.find(
+      (v: any) => v.path === 'navigation.position'
+    ).value
+
+    const dse = parser.parse(dseExpansion) as any
+    const refined = dse.updates[0]!.values.find(
+      (v: any) => v.path === 'navigation.position'
+    ).value
+
+    dse.context.should.equal('vessels.urn:mrn:imo:mmsi:338040079')
+    refined.latitude.should.be.closeTo(42.5243, 0.0001)
+    refined.longitude.should.be.closeTo(-83.2075, 0.0001)
+    // Refinement extends magnitude beyond the whole-minute DSC position.
+    refined.latitude.should.be.greaterThan(coarse.latitude)
+    Math.abs(refined.longitude).should.be.greaterThan(
+      Math.abs(coarse.longitude)
+    )
+  })
+
+  it('returns null when no preceding DSC position is known', () => {
+    const delta = new Parser().parse(dseExpansion) as any
+    should.equal(delta, null)
+  })
+
+  it('ignores multi-sentence DSE groups', () => {
+    const parser = new Parser()
+    parser.parse(dscDistress)
+    const delta = parser.parse('$CDDSE,2,1,A,3380400790,00,45894494*18') as any
+    should.equal(delta, null)
+  })
+})


### PR DESCRIPTION
A `$--DSE` sentence refines the position of a preceding `$--DSC` from whole minutes to ten-thousandths of a minute, but it carries only the fractional component — never absolute coordinates. There was no DSE hook, so this finer position was discarded entirely.

This remembers each DSC position in the parser session keyed by MMSI, then adds a DSE hook that recalls it and emits the refined `navigation.position` under the same context. DSE sentences without a preceding DSC fix, and multi-sentence groups, are ignored. Tests included.

Touches `DSC.ts` to store the position in the session, so it overlaps slightly with #336 — whichever merges first, the other rebases cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)