### PR TITLE
Attribute DSC distress relays to the casualty and read the real nature of distress

### DIFF
--- a/src/hooks/DSC.ts
+++ b/src/hooks/DSC.ts
@@ -59,6 +59,38 @@ function parsePosition(line: string): { longitude: number; latitude: number } {
   return { longitude: lon_dec, latitude: lat_dec }
 }
 
+function natureOfDistress(code: string | undefined): string {
+  switch (code) {
+    case '00': // = Fire, explosion
+      return 'fire'
+    case '01': // = Flooding
+      return 'flooding'
+    case '02': // = Collision
+      return 'collision'
+    case '03': // = Grounding
+      return 'grounding'
+    case '04': // = Listing, in danger of capsize
+      return 'listing'
+    case '05': // = Sinking
+      return 'sinking'
+    case '06': // = Disabled and adrift
+      return 'adrift'
+    case '07': // = Undesignated distres
+      return 'undesignated'
+    case '08': // = Abandoning ship
+      return 'abandon'
+    case '09': // = Piracy/armed robbery attack
+      return 'piracy'
+    case '10': // = Man overboard
+      return 'mob'
+    case '12': // = EPRIB emission
+      return 'epirb'
+    default:
+      // unassigned symbol; take no action
+      return 'unassigned'
+  }
+}
+
 const DSC: HookFn = function (
   input: ParserInput,
   _session: ParserSession
@@ -86,6 +118,7 @@ const DSC: HookFn = function (
   var get_position = false
   var distress = false
   var distress_nature = ''
+  var relayedBy: string | undefined
 
   switch (parts[2]!) {
     case '00': // routine category
@@ -106,48 +139,20 @@ const DSC: HookFn = function (
       handled = true
       get_position = true
       distress = true
-      switch (
-        parts[3]! // Nature of Distress
-      ) {
-        case '00': // = Fire, explosion
-          distress_nature = 'fire'
-          break
-        case '01': // = Flooding
-          distress_nature = 'flooding'
-          break
-        case '02': // = Collision
-          distress_nature = 'collision'
-          break
-        case '03': // = Grounding
-          distress_nature = 'grounding'
-          break
-        case '04': // = Listing, in danger of capsize
-          distress_nature = 'listing'
-          break
-        case '05': // = Sinking
-          distress_nature = 'sinking'
-          break
-        case '06': // = Disabled and adrift
-          distress_nature = 'adrift'
-          break
-        case '07': // = Undesignated distres
-          distress_nature = 'undesignated'
-          break
-        case '08': // = Abandoning ship
-          distress_nature = 'abandon'
-          break
-        case '09': // = Piracy/armed robbery attack
-          distress_nature = 'piracy'
-          break
-        case '10': // = Man overboard
-          distress_nature = 'mob'
-          break
-        case '12': // = EPRIB emission
-          distress_nature = 'epirb'
-          break
-        default:
-          // unassigned symbol; take no action
-          distress_nature = 'unassigned'
+      if (parts[0] !== '12') {
+        // A distress *relay* (all-ships 116, individual 120 or area 102
+        // format carrying the distress category): field 3 holds the relay
+        // telecommand, not a nature code — the nature is in field 8 and the
+        // casualty's MMSI in field 7. The position in field 5 is the
+        // casualty's, so the delta is attributed to the casualty, not to
+        // the relaying station.
+        distress_nature = natureOfDistress(parts[8])
+        relayedBy = mmsi
+        if (!isEmpty(parts[7])) {
+          mmsi = parts[7]!.substring(0, 9)
+        }
+      } else {
+        distress_nature = natureOfDistress(parts[3])
       }
   }
 
@@ -169,10 +174,26 @@ const DSC: HookFn = function (
     })
   }
   if (distress) {
+    var message =
+      'DSC Distress Recieved! Nature of distress: ' + distress_nature
+    if (relayedBy !== undefined) {
+      var casualty = relayedBy === mmsi ? 'an unknown vessel' : 'vessel ' + mmsi
+      message =
+        'DSC distress relay received for ' +
+        casualty +
+        ' (relayed by ' +
+        relayedBy +
+        '). Nature of distress: ' +
+        distress_nature
+      var ack = typeof parts[9] === 'string' ? parts[9]!.trim() : ''
+      if (ack !== '') {
+        message += '. Acknowledgement: ' + ack
+      }
+    }
     values.push({
       path: 'notifications.' + distress_nature,
       value: {
-        message: 'DSC Distress Recieved! Nature of distress: ' + distress_nature
+        message: message
       }
     })
   }

--- a/test/DSC.ts
+++ b/test/DSC.ts
@@ -23,6 +23,10 @@ const nmeaLineUrgency = '$CDDSC,20,3381581370,10,00,00,1423108312,1902,,,B,E*7D'
 // the casualty's.
 const nmeaLineRelay =
   '$CDDSC,16,0031600010,12,112,00,1423108312,2019,3162009110,12,,*47'
+// A relay may legitimately omit the casualty's MMSI (vessel unknown). It
+// must fall back to the relaying station's context — never be dropped.
+const nmeaLineRelayNoCasualty =
+  '$CDDSC,16,0031600010,12,112,00,1423108312,2019,,12,,*48'
 
 // Each distress nature code maps to a specific notification path. Every code
 // must be exercised so that the mapping table in DSC.js cannot silently drift.
@@ -118,6 +122,20 @@ describe('DSC', () => {
       (v: any) => v.path === 'notifications.epirb'
     )
     notification.value.message.should.contain('003160001')
+  })
+
+  it('Distress relay without a casualty MMSI falls back to the relaying station', () => {
+    const delta = new Parser().parse(nmeaLineRelayNoCasualty) as any
+
+    delta.context.should.equal('vessels.urn:mrn:imo:mmsi:003160001')
+    delta.updates[0]!.values.should.containItemWithProperty(
+      'path',
+      'notifications.epirb'
+    )
+    const notification = delta.updates[0]!.values.find(
+      (v: any) => v.path === 'notifications.epirb'
+    )
+    notification.value.message.should.contain('unknown vessel')
   })
 
   it("Doesn't choke on empty sentences", () => {

--- a/test/DSC.ts
+++ b/test/DSC.ts
@@ -16,6 +16,14 @@ const nmeaLineUnhandled =
 const nmeaLineSafety = '$CDDSC,20,3381581370,08,00,00,1423108312,1902,,,B,E*74'
 const nmeaLineUrgency = '$CDDSC,20,3381581370,10,00,00,1423108312,1902,,,B,E*7D'
 
+// A distress *relay*: a coast station (field 1) re-broadcasts another
+// vessel's distress as an all-ships call (format 116). Field 3 is the relay
+// telecommand (112), not a nature code — the nature (12 = EPIRB) is in
+// field 8 and the casualty's MMSI in field 7. The position in field 5 is
+// the casualty's.
+const nmeaLineRelay =
+  '$CDDSC,16,0031600010,12,112,00,1423108312,2019,3162009110,12,,*47'
+
 // Each distress nature code maps to a specific notification path. Every code
 // must be exercised so that the mapping table in DSC.js cannot silently drift.
 const distressCases = [
@@ -82,6 +90,34 @@ describe('DSC', () => {
         (v: any) => v.path === path
       )!.value.message.should.match(/DSC Distress Recieved/)
     })
+  })
+
+  it('Distress relay reads the nature from field 8, not the relay telecommand', () => {
+    const delta = new Parser().parse(nmeaLineRelay) as any
+
+    delta.updates[0]!.values.should.containItemWithProperty(
+      'path',
+      'notifications.epirb'
+    )
+  })
+
+  it('Distress relay is attributed to the casualty, not the relaying station', () => {
+    const delta = new Parser().parse(nmeaLineRelay) as any
+
+    delta.context.should.equal('vessels.urn:mrn:imo:mmsi:316200911')
+    delta.updates[0]!.values.should.containItemWithProperty(
+      'path',
+      'navigation.position'
+    )
+  })
+
+  it('Distress relay notification names the relaying station', () => {
+    const delta = new Parser().parse(nmeaLineRelay) as any
+
+    const notification = delta.updates[0]!.values.find(
+      (v: any) => v.path === 'notifications.epirb'
+    )
+    notification.value.message.should.contain('003160001')
   })
 
   it("Doesn't choke on empty sentences", () => {


### PR DESCRIPTION
While testing DSC handling against a radio that forwards mayday relays, I found the hook mis-parses distress *relays* — an all-ships (116), individual (120) or area (102) call carrying the distress category. Worked example (a coast station relaying an EPIRB activation):

```
$CDDSC,16,0031600010,12,112,00,1423108312,2019,3162009110,12,,*47
```

Three things go wrong today:

1. **Nature of distress is read from the wrong field.** In a relay, field 3 is the relay telecommand (`112`), not a nature code — so every relay resolves to `notifications.unassigned`. The real nature is in field 8 (`12` = EPIRB here).
2. **The distress is attributed to the wrong vessel.** The position in field 5 and the distress itself belong to the *casualty* (field 7, `316200911`), but the delta is published under the relaying station's context (`003160001`). A consumer plotting the distress would mark the coast station's MMSI at the casualty's position.
3. **The acknowledgement char (field 9, R/B/S) is dropped.**

This PR teaches the distress branch to detect a relay (category 12 with a non-112 format specifier): nature comes from field 8 via the extracted `natureOfDistress()` (the same switch, now shared with the first-party path), the delta context switches to the casualty (trailing zero stripped, same as field 1), the notification message names the relaying station, and the ack char is appended to the message when present. If the casualty MMSI is absent (vessel unknown — legitimate for a relay), it falls back to the relaying station's context rather than dropping a distress. First-party alerts (format 112) are untouched — all existing tests pass unmodified.

Heads up: this overlaps #336 in the same `switch` — happy to rebase whichever lands second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GpBXJ9buMsou2Fxt5heT1x
